### PR TITLE
feat: add blockchain position tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ monitoring_output.json
 
 # Development
 contracts/
+.claude/settings.local.json

--- a/src/api/minters/blockchain-minters.service.ts
+++ b/src/api/minters/blockchain-minters.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ethers } from 'ethers';
+import { DecentralizedEUROABI, ADDRESS } from '@deuro/eurocoin';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class BlockchainMintersService {
+  private readonly logger = new Logger(BlockchainMintersService.name);
+  private provider: ethers.Provider;
+  private deuroContract: ethers.Contract;
+  private cachedCount: number | null = null;
+  private lastFetch: number = 0;
+  private readonly CACHE_DURATION = 60000; // 1 minute cache
+
+  constructor(private readonly configService: ConfigService) {
+    const monitoringConfig = this.configService.get('monitoring');
+    this.provider = new ethers.JsonRpcProvider(monitoringConfig.rpcUrl);
+    const blockchainId = monitoringConfig.blockchainId;
+    const deuroAddress = ADDRESS[blockchainId].decentralizedEURO;
+    this.deuroContract = new ethers.Contract(deuroAddress, DecentralizedEUROABI, this.provider);
+  }
+
+  async getTotalMintersFromBlockchain(): Promise<number> {
+    try {
+      // Check cache
+      const now = Date.now();
+      if (this.cachedCount !== null && (now - this.lastFetch) < this.CACHE_DURATION) {
+        return this.cachedCount;
+      }
+
+      this.logger.log('Fetching total minters from blockchain...');
+
+      // Fetch all MinterApplied events
+      const appliedFilter = this.deuroContract.filters.MinterApplied();
+      const appliedEvents = await this.deuroContract.queryFilter(appliedFilter, 0, 'latest');
+
+      // Get unique minter addresses
+      const uniqueMinters = new Set<string>();
+      for (const event of appliedEvents) {
+        // Type guard for EventLog vs Log
+        if ('args' in event && event.args?.[0]) {
+          uniqueMinters.add(event.args[0].toLowerCase());
+        }
+      }
+
+      this.cachedCount = uniqueMinters.size;
+      this.lastFetch = now;
+
+      this.logger.log(`Found ${uniqueMinters.size} total unique minter applications`);
+      return uniqueMinters.size;
+    } catch (error) {
+      this.logger.error('Error fetching minters from blockchain:', error);
+      // Return cached value if available, otherwise 0
+      return this.cachedCount || 0;
+    }
+  }
+}

--- a/src/api/minters/minter.controller.ts
+++ b/src/api/minters/minter.controller.ts
@@ -1,13 +1,17 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags, ApiOkResponse, ApiQuery } from '@nestjs/swagger';
 import { MinterService } from './minter.service';
+import { BlockchainMintersService } from './blockchain-minters.service';
 import { MinterStateDto, MinterStatus } from '../../common/dto/minter.dto';
 import { BridgeStateDto } from '../../common/dto/stablecoinBridge.dto';
 
 @ApiTags('Minters')
 @Controller('minters')
 export class MinterController {
-	constructor(private readonly minterService: MinterService) {}
+	constructor(
+		private readonly minterService: MinterService,
+		private readonly blockchainMintersService: BlockchainMintersService
+	) {}
 
 	@Get()
 	@ApiQuery({ name: 'status', enum: MinterStatus, required: false })
@@ -23,5 +27,12 @@ export class MinterController {
 	async getBridges(@Query('all') all?: string): Promise<BridgeStateDto[]> {
 		if (all === 'true') return this.minterService.getAllBridges();
 		return this.minterService.getActiveBridges();
+	}
+
+	@Get('total-count')
+	@ApiOkResponse({ type: Number })
+	async getTotalMintersCount(): Promise<{ count: number }> {
+		const count = await this.blockchainMintersService.getTotalMintersFromBlockchain();
+		return { count };
 	}
 }

--- a/src/api/minters/minter.module.ts
+++ b/src/api/minters/minter.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { MinterController } from './minter.controller';
 import { MinterService } from './minter.service';
+import { BlockchainMintersService } from './blockchain-minters.service';
 import { DatabaseModule } from '../../database/database.module';
 
 @Module({
 	imports: [DatabaseModule],
 	controllers: [MinterController],
-	providers: [MinterService],
-	exports: [MinterService],
+	providers: [MinterService, BlockchainMintersService],
+	exports: [MinterService, BlockchainMintersService],
 })
 export class MinterModule {}

--- a/src/api/positions/blockchain-positions.service.ts
+++ b/src/api/positions/blockchain-positions.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ethers } from 'ethers';
+import { BlockchainService } from '../../blockchain/blockchain.service';
+
+@Injectable()
+export class BlockchainPositionsService {
+	private readonly logger = new Logger(BlockchainPositionsService.name);
+	private mintingHubContract: ethers.Contract;
+
+	// Cache for 1 minute
+	private cachedCount: number | null = null;
+	private lastFetch: number = 0;
+	private readonly CACHE_DURATION = 60 * 1000; // 1 minute
+
+	constructor(private readonly blockchainService: BlockchainService) {
+		this.mintingHubContract = this.blockchainService.getContracts().mintingHubContract;
+	}
+
+	async getTotalPositionsFromBlockchain(): Promise<number> {
+		// Check cache
+		const now = Date.now();
+		if (this.cachedCount !== null && (now - this.lastFetch) < this.CACHE_DURATION) {
+			this.logger.debug(`Returning cached position count: ${this.cachedCount}`);
+			return this.cachedCount;
+		}
+
+		try {
+			this.logger.log('Fetching total positions from blockchain...');
+
+			// Fetch all PositionOpened events
+			const positionOpenedFilter = this.mintingHubContract.filters.PositionOpened();
+			const deploymentBlock = this.blockchainService.getDeploymentBlock();
+			const positionOpenedEvents = await this.mintingHubContract.queryFilter(
+				positionOpenedFilter,
+				deploymentBlock,
+				'latest'
+			);
+
+			// Get unique position addresses
+			const uniquePositions = new Set<string>();
+			for (const event of positionOpenedEvents) {
+				if ('args' in event && event.args?.[1]) {
+					// args[1] is the position address according to the event signature
+					uniquePositions.add(event.args[1].toLowerCase());
+				}
+			}
+
+			const count = uniquePositions.size;
+			this.logger.log(`Found ${count} unique positions on blockchain`);
+
+			// Update cache
+			this.cachedCount = count;
+			this.lastFetch = now;
+
+			return count;
+		} catch (error) {
+			this.logger.error('Error fetching positions from blockchain:', error);
+			// If we have cached data and encounter an error, return cached data
+			if (this.cachedCount !== null) {
+				this.logger.warn('Returning stale cached data due to error');
+				return this.cachedCount;
+			}
+			throw error;
+		}
+	}
+
+	// Force refresh the cache
+	async refreshCache(): Promise<number> {
+		this.cachedCount = null;
+		this.lastFetch = 0;
+		return this.getTotalPositionsFromBlockchain();
+	}
+}

--- a/src/api/positions/position.controller.ts
+++ b/src/api/positions/position.controller.ts
@@ -2,11 +2,15 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags, ApiOkResponse, ApiQuery } from '@nestjs/swagger';
 import { PositionService } from './position.service';
 import { PositionStateDto } from '../../common/dto';
+import { BlockchainPositionsService } from './blockchain-positions.service';
 
 @ApiTags('Positions')
 @Controller('positions')
 export class PositionController {
-	constructor(private readonly positionService: PositionService) {}
+	constructor(
+		private readonly positionService: PositionService,
+		private readonly blockchainPositionsService: BlockchainPositionsService,
+	) {}
 
 	@Get()
 	@ApiQuery({ name: 'live', type: 'boolean', required: false })
@@ -14,5 +18,12 @@ export class PositionController {
 	@ApiOkResponse({ type: [PositionStateDto] })
 	async getPositions(@Query('live') live?: string, @Query('collateral') collateral?: string): Promise<PositionStateDto[]> {
 		return this.positionService.getPositions(live, collateral);
+	}
+
+	@Get('total-count')
+	@ApiOkResponse({ type: Number })
+	async getTotalPositionsCount(): Promise<{ count: number }> {
+		const count = await this.blockchainPositionsService.getTotalPositionsFromBlockchain();
+		return { count };
 	}
 }

--- a/src/api/positions/position.module.ts
+++ b/src/api/positions/position.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { PositionController } from './position.controller';
 import { PositionService } from './position.service';
+import { BlockchainPositionsService } from './blockchain-positions.service';
 import { DatabaseModule } from '../../database/database.module';
+import { BlockchainModule } from '../../blockchain/blockchain.module';
 
 @Module({
-	imports: [DatabaseModule],
+	imports: [DatabaseModule, BlockchainModule],
 	controllers: [PositionController],
-	providers: [PositionService],
+	providers: [PositionService, BlockchainPositionsService],
 })
 export class PositionModule {}


### PR DESCRIPTION
## Summary
- Added blockchain-based position tracking to complement database tracking
- Implemented discrepancy detection between blockchain and database position counts
- Added visual warnings when position data is incomplete

## Changes
- Created `BlockchainPositionsService` to fetch total positions directly from blockchain via PositionOpened events
- Added `/positions/total-count` API endpoint
- Updated dashboard to display both blockchain and database position counts
- Added warning banner when counts don't match (currently showing 56 blockchain vs 40 database)

## Technical Details
- Uses MintingHub contract's PositionOpened events to count all positions ever created
- Implements 1-minute cache to optimize blockchain queries
- Follows same pattern as minter tracking implementation
- Parallel API calls in frontend for better performance

## Testing
- API endpoint tested: returns 56 positions from blockchain
- Database shows 40 positions
- Discrepancy warning displays correctly
- Cache mechanism working as expected