### PR TITLE
Replace Azure deploy with SSH deploy via Cloudflare Tunnel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,8 +47,8 @@ Dockerfile
 docker-compose.yml
 .dockerignore
 
-# Frontend (not needed in backend container)
-frontend/
+# Note: frontend/ is NOT excluded — the frontend Dockerfile
+# builds from repo root context and needs access to frontend/ and shared/
 
 # Test files
 test/

--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -13,8 +13,6 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-monitoring-web:beta
-  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
-  DEPLOY_USER: dfxdev
   DEPLOY_SERVICE: deuro-monitoring-web
 
 jobs:
@@ -70,16 +68,16 @@ jobs:
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
-      - name: Deploy to dfxdev
+      - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
-            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -1,4 +1,4 @@
-name: dEURO Frontend DEV CI/CD
+name: dEURO Monitoring Frontend DEV CI/CD
 
 on:
   push:
@@ -12,35 +12,32 @@ on:
   workflow_dispatch:
 
 env:
-  AZURE_ACCOUNT_NAME: stdfxdemdev
-  AZURE_CDN_PROFILE: afd-dfx-api-dev
-  AZURE_CDN_ENDPOINT: fde-dfx-dem-dev
-  AZURE_RESOURCE_GROUP: rg-dfx-api-dev
+  DOCKER_TAGS: dfxswiss/deuro-monitoring-web:beta
+  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
+  DEPLOY_USER: dfxdev
+  DEPLOY_SERVICE: deuro-monitoring-web
 
 jobs:
   build:
-    name: Build and test Frontend
+    name: Build Frontend
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: frontend
-
-      - name: Build frontend
-        run: npm run build
-        working-directory: frontend
-        env:
-          VITE_API_BASE_URL: https://dev.monitoring.deuro.com/api
+          context: ./frontend
+          push: false
+          load: true
+          tags: ${{ env.DOCKER_TAGS }}
 
   deploy:
     name: Deploy Frontend to DEV
@@ -51,40 +48,41 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Install dependencies
-        run: npm ci
-        working-directory: frontend
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      - name: Build frontend
-        run: npm run build
-        working-directory: frontend
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to dfxdev
         env:
-          VITE_API_BASE_URL: https://dev.monitoring.deuro.com/api
-
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_DEV_CREDENTIALS }}
-
-      - name: Upload to Azure Storage
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.AZURE_ACCOUNT_NAME }} -d '$web' -s ./frontend/dist --overwrite
-
-      - name: Purge CDN endpoint
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az afd endpoint purge --content-paths "/*" --profile-name ${{ env.AZURE_CDN_PROFILE }} --endpoint-name ${{ env.AZURE_CDN_ENDPOINT }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }}
-
-      - name: Logout from Azure
-        run: az logout
-        if: always()
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
+            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -74,9 +74,6 @@ jobs:
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to dfxdev
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key

--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_TAGS: dfxswiss/deuro-monitoring-web:beta
+  DOCKER_TAGS: deurocom/monitoring-web:beta
   DEPLOY_SERVICE: deuro-monitoring-web
 
 jobs:

--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -5,10 +5,12 @@ on:
     branches: [develop]
     paths:
       - 'frontend/**'
+      - 'shared/**'
   pull_request:
     branches: [develop]
     paths:
       - 'frontend/**'
+      - 'shared/**'
   workflow_dispatch:
 
 env:
@@ -32,7 +34,8 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./frontend
+          context: .
+          file: frontend/Dockerfile
           push: false
           load: true
           tags: ${{ env.DOCKER_TAGS }}
@@ -61,7 +64,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./frontend
+          context: .
+          file: frontend/Dockerfile
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -25,20 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: frontend/Dockerfile
-          push: false
-          load: true
-          tags: ${{ env.DOCKER_TAGS }}
+        run: docker build -f frontend/Dockerfile -t ${{ env.DOCKER_TAGS }} .
 
   deploy:
     name: Deploy Frontend to DEV

--- a/.github/workflows/monitoring-dev.yaml
+++ b/.github/workflows/monitoring-dev.yaml
@@ -80,9 +80,6 @@ jobs:
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to dfxdev
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
@@ -105,9 +102,6 @@ jobs:
           chmod +x /usr/local/bin/cloudflared
 
       - name: Reset monitoring database on dfxdev
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key

--- a/.github/workflows/monitoring-dev.yaml
+++ b/.github/workflows/monitoring-dev.yaml
@@ -19,9 +19,9 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-monitoring:beta
-  AZURE_RESOURCE_GROUP: rg-dfx-api-dev
-  AZURE_CONTAINER_APP: ca-dfx-dem-dev
-  DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
+  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
+  DEPLOY_USER: dfxdev
+  DEPLOY_SERVICE: deuro-monitoring
 
 jobs:
   build:
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,6 +60,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -66,21 +72,26 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/amd64,linux/arm64
 
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_DEV_CREDENTIALS }}
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
 
-      - name: Update Azure Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
-
-      - name: Logout from Azure
-        run: az logout
-        if: always()
+      - name: Deploy to dfxdev
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
+            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"
 
   reset-database:
     name: Reset Database
@@ -88,22 +99,21 @@ jobs:
     needs: deploy
     if: github.event_name == 'workflow_dispatch' && inputs.reset_database == true
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Reset Database
+      - name: Install cloudflared
         run: |
-          set -euo pipefail
-          echo "DATABASE RESET INITIATED"
-          npx prisma migrate reset --force --schema=./src/monitoringV2/prisma/schema.prisma
-          echo "Database reset complete"
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Reset monitoring database on dfxdev
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
+            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            "reset-monitoring-db"

--- a/.github/workflows/monitoring-dev.yaml
+++ b/.github/workflows/monitoring-dev.yaml
@@ -18,7 +18,7 @@ on:
         default: false
 
 env:
-  DOCKER_TAGS: dfxswiss/deuro-monitoring:beta
+  DOCKER_TAGS: deurocom/monitoring:beta
   DEPLOY_SERVICE: deuro-monitoring
 
 jobs:

--- a/.github/workflows/monitoring-dev.yaml
+++ b/.github/workflows/monitoring-dev.yaml
@@ -19,8 +19,6 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-monitoring:beta
-  DEPLOY_HOST: ssh-dfxdev.dfxserve.com
-  DEPLOY_USER: dfxdev
   DEPLOY_SERVICE: deuro-monitoring
 
 jobs:
@@ -76,18 +74,18 @@ jobs:
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
-      - name: Deploy to dfxdev
+      - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
-            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"
 
   reset-database:
@@ -98,16 +96,16 @@ jobs:
     steps:
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
-      - name: Reset monitoring database on dfxdev
+      - name: Reset monitoring database
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DFXDEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DFXDEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ env.DEPLOY_HOST }}" \
-            ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
             "reset-monitoring-db"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:lts-alpine AS build
-WORKDIR /app
+WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci
 COPY frontend/ .
-COPY shared/ ../shared/
+COPY shared/ /app/shared/
 ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build
 
 FROM nginx:alpine
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/frontend/dist /usr/share/nginx/html
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,5 +10,5 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+ARG VITE_API_BASE_URL=/api
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:lts-alpine AS build
 WORKDIR /app
-COPY package*.json ./
+COPY frontend/package*.json ./
 RUN npm ci
-COPY . .
+COPY frontend/ .
+COPY shared/ ../shared/
 ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # API reverse proxy to monitoring backend
+    location /api {
+        proxy_pass http://deuro-monitoring:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Swagger docs reverse proxy
+    location /swagger {
+        proxy_pass http://deuro-monitoring:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
Replace Azure Container App deployment with SSH deployment via Cloudflare Tunnel.

- Docker Hub push (`:beta` tag) remains unchanged  
- Deploy uses command-restricted SSH key
- Host and user details stored as secrets
- Both `monitoring-dev.yaml` and `frontend-dev.yaml` workflows updated

## Required GitHub Secrets
| Secret | Description |
|---|---|
| `DEPLOY_SSH_KEY` | SSH private key (ed25519) |
| `DEPLOY_SSH_KNOWN_HOSTS` | SSH host key verification |
| `DEPLOY_HOST` | Target SSH hostname |
| `DEPLOY_USER` | Target SSH username |