### PR TITLE
Fix nginx reverse proxy: strip /api prefix

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,9 +3,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # API reverse proxy to monitoring backend
-    location /api {
-        proxy_pass http://deuro-monitoring:3000;
+    # API reverse proxy to monitoring backend (strip /api prefix)
+    location /api/ {
+        proxy_pass http://deuro-monitoring:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -14,7 +14,7 @@ server {
 
     # Swagger docs reverse proxy
     location /swagger {
-        proxy_pass http://deuro-monitoring:3000;
+        proxy_pass http://deuro-monitoring:3000/swagger;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
The frontend fetches `/api/health`, `/api/positions`, etc. but the backend expects `/health`, `/positions`. The nginx proxy now strips the `/api` prefix before forwarding to the backend.