### PR TITLE
fix: pass CoinGecko API key to FX rate requests

### DIFF
--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -64,4 +64,8 @@ export class AppConfigService {
 	get alertTimeframeHours(): number {
 		return this.monitoringConfig.alertTimeframeHours || 12;
 	}
+
+	get coingeckoApiKey(): string | undefined {
+		return this.monitoringConfig.coingeckoApiKey || undefined;
+	}
 }

--- a/src/config/monitoring.config.ts
+++ b/src/config/monitoring.config.ts
@@ -66,6 +66,10 @@ export class MonitoringConfig {
 	@IsNumber()
 	@Min(1)
 	alertTimeframeHours?: number;
+
+	@IsOptional()
+	@IsString()
+	coingeckoApiKey?: string;
 }
 
 export default registerAs('monitoring', () => {
@@ -87,6 +91,7 @@ export default registerAs('monitoring', () => {
 	config.telegramChatId = process.env.TELEGRAM_CHAT_ID || '';
 	config.telegramAlertsEnabled = (process.env.TELEGRAM_ALERTS_ENABLED || 'false').toLowerCase() === 'true';
 	config.alertTimeframeHours = parseInt(process.env.ALERT_TIMEFRAME_HOURS || '12');
+	config.coingeckoApiKey = process.env.COINGECKO_API_KEY || '';
 
 	const errors = validateSync(plainToClass(MonitoringConfig, config));
 	if (errors.length > 0) throw new Error(`Config validation failed: ${errors}`);

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -185,8 +185,12 @@ export class PriceService {
 		chfCached: PriceCacheEntry | undefined
 	): Promise<{ eur: number; chf: number }> {
 		try {
+			const apiKey = this.appConfigService.coingeckoApiKey;
+			const headers: Record<string, string> = { accept: 'application/json' };
+			if (apiKey) headers['x-cg-demo-api-key'] = apiKey;
+
 			const response = await axios.get('https://api.coingecko.com/api/v3/simple/price?ids=usd&vs_currencies=eur,chf', {
-				headers: { accept: 'application/json' },
+				headers,
 				timeout: 10000,
 			});
 


### PR DESCRIPTION
## Summary
- Read optional `COINGECKO_API_KEY` env var and send it as `x-cg-demo-api-key` header on CoinGecko FX rate requests
- Avoids free-tier rate limits that cause recurring 429 errors every time the 1h cache expires

Requires adding `COINGECKO_API_KEY` to the monitoring container env in docker-compose.

## Test plan
- [ ] Add `COINGECKO_API_KEY: ${COINGECKO_API_KEY}` to monitoring service in docker-compose on dfxdev
- [ ] Deploy and verify no more `429` errors in monitoring logs