### PR TITLE
Switch to ARM64-only Docker builds for Apple Silicon servers

### DIFF
--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: Build Frontend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
 
   deploy:
     name: Deploy Frontend to DEV
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
@@ -43,9 +43,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,11 +53,11 @@ jobs:
           file: frontend/Dockerfile
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to server

--- a/.github/workflows/monitoring-dev.yaml
+++ b/.github/workflows/monitoring-dev.yaml
@@ -24,13 +24,10 @@ env:
 jobs:
   build:
     name: Build and test Monitoring
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,7 +42,7 @@ jobs:
 
   deploy:
     name: Deploy Monitoring to DEV
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
@@ -58,9 +55,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -70,11 +64,11 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
 
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
       - name: Deploy to server
@@ -90,13 +84,13 @@ jobs:
 
   reset-database:
     name: Reset Database
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: deploy
     if: github.event_name == 'workflow_dispatch' && inputs.reset_database == true
     steps:
       - name: Install cloudflared
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
           chmod +x /usr/local/bin/cloudflared
 
       - name: Reset monitoring database

--- a/.github/workflows/monitoring-prd.yaml
+++ b/.github/workflows/monitoring-prd.yaml
@@ -19,14 +19,12 @@ on:
 
 env:
   DOCKER_TAGS: dfxswiss/deuro-monitoring:latest
-  AZURE_RESOURCE_GROUP: rg-dfx-api-prd
-  AZURE_CONTAINER_APP: ca-dfx-dem-prd
-  DEPLOY_INFO: ${{ github.ref_name }}-${{ github.sha }}
+  DEPLOY_SERVICE: deuro-monitoring
 
 jobs:
   build:
     name: Build and test Monitoring
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +42,7 @@ jobs:
 
   deploy:
     name: Deploy Monitoring to PRD
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
@@ -66,26 +64,28 @@ jobs:
           context: .
           push: true
           tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64
 
-      - name: Log in to Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DFX_PRD_CREDENTIALS }}
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
 
-      - name: Update Azure Container App
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
-
-      - name: Logout from Azure
-        run: az logout
-        if: always()
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"
 
   reset-db:
     name: Reset PRD Database
     needs: deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch' && inputs.reset_database == true
     steps:


### PR DESCRIPTION
## Summary
- Switch all CI/CD runners from `ubuntu-latest` to `ubuntu-24.04-arm` for native ARM64 builds
- Remove QEMU emulation setup (no longer needed with native ARM64 runners)
- Build only `linux/arm64` Docker images instead of multi-arch (`linux/amd64,linux/arm64`)
- Replace Azure Container App deployment in PRD with SSH deploy via cloudflared (same pattern as DEV)
- Use `cloudflared-linux-arm64` binary matching the ARM64 runner architecture

## Affected workflows
- `monitoring-dev.yaml` — runner, QEMU removal, platform, cloudflared URL
- `monitoring-prd.yaml` — runner, platform, Azure → SSH deploy
- `frontend-dev.yaml` — runner, QEMU removal, platform, cloudflared URL
- `frontend-prd.yaml` — NOT modified (Azure Storage deploy, not Docker)

## Test plan
- [ ] Verify monitoring DEV workflow triggers and builds ARM64 image
- [ ] Verify monitoring PRD workflow triggers and deploys via SSH
- [ ] Verify frontend DEV workflow triggers and builds ARM64 image
- [ ] Confirm Docker images are ARM64-only on Docker Hub