### PR TITLE
Use deurocom registry, migrate frontend PRD to Docker deploy

### DIFF
--- a/.github/workflows/frontend-dev.yaml
+++ b/.github/workflows/frontend-dev.yaml
@@ -63,10 +63,10 @@ jobs:
       - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
-            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/frontend-prd.yaml
+++ b/.github/workflows/frontend-prd.yaml
@@ -1,90 +1,72 @@
-name: dEURO Frontend PRD CI/CD
+name: dEURO Monitoring Frontend PRD CI/CD
 
 on:
   push:
     branches: [main]
     paths:
       - 'frontend/**'
+      - 'shared/**'
   pull_request:
     branches: [main]
     paths:
       - 'frontend/**'
+      - 'shared/**'
   workflow_dispatch:
 
 env:
-  AZURE_ACCOUNT_NAME: stdfxdemprd
-  AZURE_CDN_PROFILE: afd-dfx-api-prd
-  AZURE_CDN_ENDPOINT: fde-dfx-dem-prd
-  AZURE_RESOURCE_GROUP: rg-dfx-api-prd
+  DOCKER_TAGS: deurocom/monitoring-web:latest
+  DEPLOY_SERVICE: deuro-monitoring-web
 
 jobs:
   build:
-    name: Build and test Frontend
-    runs-on: ubuntu-latest
+    name: Build Frontend
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: frontend
-
-      - name: Build frontend
-        run: npm run build
-        working-directory: frontend
-        env:
-          VITE_API_BASE_URL: https://monitoring.deuro.com/api
+      - name: Build Docker image
+        run: docker build -f frontend/Dockerfile -t ${{ env.DOCKER_TAGS }} .
 
   deploy:
     name: Deploy Frontend to PRD
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Install dependencies
-        run: npm ci
-        working-directory: frontend
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build frontend
-        run: npm run build
-        working-directory: frontend
-        env:
-          VITE_API_BASE_URL: https://monitoring.deuro.com/api
-
-      - name: Log in to Azure
-        uses: azure/login@v2
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
         with:
-          creds: ${{ secrets.DFX_PRD_CREDENTIALS }}
+          context: .
+          file: frontend/Dockerfile
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64
 
-      - name: Upload to Azure Storage
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.AZURE_ACCOUNT_NAME }} -d '$web' -s ./frontend/dist --overwrite
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
 
-      - name: Purge CDN endpoint
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az afd endpoint purge --content-paths "/*" --profile-name ${{ env.AZURE_CDN_PROFILE }} --endpoint-name ${{ env.AZURE_CDN_ENDPOINT }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }}
-
-      - name: Logout from Azure
-        run: az logout
-        if: always()
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/monitoring-dev.yaml
+++ b/.github/workflows/monitoring-dev.yaml
@@ -74,12 +74,12 @@ jobs:
       - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
-            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"
 
   reset-database:
@@ -96,10 +96,10 @@ jobs:
       - name: Reset monitoring database
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
-            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             "reset-monitoring-db"

--- a/.github/workflows/monitoring-prd.yaml
+++ b/.github/workflows/monitoring-prd.yaml
@@ -18,7 +18,7 @@ on:
         default: false
 
 env:
-  DOCKER_TAGS: dfxswiss/deuro-monitoring:latest
+  DOCKER_TAGS: deurocom/monitoring:latest
   DEPLOY_SERVICE: deuro-monitoring
 
 jobs:

--- a/.github/workflows/monitoring-prd.yaml
+++ b/.github/workflows/monitoring-prd.yaml
@@ -86,25 +86,20 @@ jobs:
     name: Reset PRD Database
     needs: deploy
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 15
     if: github.event_name == 'workflow_dispatch' && inputs.reset_database == true
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Reset Database
+      - name: Install cloudflared
         run: |
-          set -euo pipefail
-          echo "PRODUCTION DATABASE RESET INITIATED"
-          npx prisma migrate reset --force --schema=./src/monitoringV2/prisma/schema.prisma
-          echo "Production database reset complete"
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_PRD }}
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Reset monitoring database
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "reset-monitoring-db"


### PR DESCRIPTION
## Summary
- Switch monitoring PRD image from `dfxswiss/deuro-monitoring:latest` to `deurocom/monitoring:latest`
- Migrate frontend PRD from Azure Storage + CDN to Docker + SSH deploy (matching DEV pattern)
- Frontend PRD image: `deurocom/monitoring-web:latest`
- Rename deploy secrets to consistent `DEPLOY_DEV_*` / `DEPLOY_PRD_*` pattern
- Fix PRD database reset to use SSH instead of direct DB connection

## Test plan
- [ ] Verify monitoring backend CI deploys correctly
- [ ] Verify frontend CI builds Docker image and deploys correctly
- [ ] Verify monitoring.deuro.com works after deploy