### PR TITLE
Cache stale FX rates on failure to prevent 429 spam

### DIFF
--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -213,10 +213,16 @@ export class PriceService {
 			return { eur, chf };
 		} catch (error) {
 			this.logger.error('Failed to fetch FX rates:', error.message || error);
-			return {
-				eur: eurCached ? Number(eurCached.value) : 1,
-				chf: chfCached ? Number(chfCached.value) : 1,
-			};
+
+			const eur = eurCached ? Number(eurCached.value) : 1;
+			const chf = chfCached ? Number(chfCached.value) : 1;
+
+			// Refresh cache timestamps so we don't retry on every call while rate-limited
+			const now = Date.now();
+			this.priceCache.set('usd-eur-rate', { value: String(eur), timestamp: now });
+			this.priceCache.set('usd-chf-rate', { value: String(chf), timestamp: now });
+
+			return { eur, chf };
 		}
 	}
 


### PR DESCRIPTION
## Summary
- When CoinGecko returns HTTP 429 (rate limit), the fallback cache values were returned but the cache **timestamp was not refreshed**
- This caused every subsequent `getFxRates()` call in the same monitoring cycle to retry the API and fail again (~3x per 5-minute cycle)
- Fix: re-cache stale values with a fresh timestamp so they're treated as valid for the full 1-hour FX TTL

## Test plan
- [ ] Verify FX rate errors drop from ~3/cycle to max 1/hour after deploy
- [ ] Confirm token prices still update correctly (EUR conversion uses cached rate)