### PR TITLE
fix: use CoinGecko Pro API endpoint for FX rates

### DIFF
--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -187,9 +187,10 @@ export class PriceService {
 		try {
 			const apiKey = this.appConfigService.coingeckoApiKey;
 			const headers: Record<string, string> = { accept: 'application/json' };
-			if (apiKey) headers['x-cg-demo-api-key'] = apiKey;
+			const baseUrl = apiKey ? 'https://pro-api.coingecko.com' : 'https://api.coingecko.com';
+			if (apiKey) headers['x-cg-pro-api-key'] = apiKey;
 
-			const response = await axios.get('https://api.coingecko.com/api/v3/simple/price?ids=usd&vs_currencies=eur,chf', {
+			const response = await axios.get(`${baseUrl}/api/v3/simple/price?ids=usd&vs_currencies=eur,chf`, {
 				headers,
 				timeout: 10000,
 			});


### PR DESCRIPTION
## Summary
- Use `pro-api.coingecko.com` and `x-cg-pro-api-key` header when API key is configured
- Falls back to free API (`api.coingecko.com` + `x-cg-demo-api-key`) when no key is set
- Fixes persistent 400 errors on FX rate fetches (Pro key was sent with Demo header/endpoint)

This fix was originally in commit ab3198a on the old `fix/coingecko-api-key` branch but was not included in the squash merge of PR #33.