### PR TITLE
Alert on mini-lifetime clones and expired positions in phase 2

### DIFF
--- a/src/monitoringV2/events.config.ts
+++ b/src/monitoringV2/events.config.ts
@@ -39,7 +39,7 @@ export const EVENT_CONFIG: Record<string, EventConfig> = {
 
 	// Profit/Loss events
 	Profit: { severity: EventSeverity.LOW, enabled: false },
-	Loss: { severity: EventSeverity.MEDIUM, enabled: true },
+	Loss: { severity: EventSeverity.HIGH, enabled: true },
 	ProfitDistributed: { severity: EventSeverity.LOW, enabled: false },
 
 	// Savings events

--- a/src/monitoringV2/monitoring.service.ts
+++ b/src/monitoringV2/monitoring.service.ts
@@ -134,6 +134,8 @@ export class MonitoringService implements OnModuleInit {
 		await this.collateralService.syncCollaterals(); // sync collateral states
 		await this.minterService.syncMinters(); // sync minter states
 		await this.deuroService.syncState(); // sync dEURO global state
+		await this.positionService.checkMiniLifetimeClones(this.telegramService); // alert on suspicious short-lifetime clones
+		await this.positionService.checkExpiredInPhase2(this.telegramService); // alert on expired positions in forced-sale decay
 		await this.telegramService.sendPendingAlerts(); // send pending telegram alerts
 
 		// Mark full cycle as completed

--- a/src/monitoringV2/monitoring.service.ts
+++ b/src/monitoringV2/monitoring.service.ts
@@ -134,8 +134,10 @@ export class MonitoringService implements OnModuleInit {
 		await this.collateralService.syncCollaterals(); // sync collateral states
 		await this.minterService.syncMinters(); // sync minter states
 		await this.deuroService.syncState(); // sync dEURO global state
-		await this.positionService.checkMiniLifetimeClones(this.telegramService); // alert on suspicious short-lifetime clones
-		await this.positionService.checkExpiredInPhase2(this.telegramService); // alert on expired positions in forced-sale decay
+		await this.positionService.checkMiniLifetimeClones(this.telegramService); // suspicious short-lifetime clones
+		await this.positionService.checkExpiringSoon(this.telegramService); // 24h heads-up before expiration
+		await this.positionService.checkExpired(this.telegramService); // transition into expired status
+		await this.positionService.checkExpiredInPhase2(this.telegramService); // phase 2 of forced-sale decay
 		await this.telegramService.sendPendingAlerts(); // send pending telegram alerts
 
 		// Mark full cycle as completed

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -6,6 +6,10 @@ import { ethers } from 'ethers';
 import { ProviderService } from './provider.service';
 import { PositionRepository } from './prisma/repositories/position.repository';
 import { EventsRepository } from './prisma/repositories/events.repository';
+import { TelegramService } from './telegram.service';
+
+// Anything below is suspicious for a clone — the WFPS attacker used a 36-second clone.
+const MINI_LIFETIME_THRESHOLD_SECONDS = 86_400n; // 1 day
 
 @Injectable()
 export class PositionService {
@@ -139,5 +143,76 @@ export class PositionService {
 
 		this.logger.log(`Fetched position data for ${results.length} positions via multicall`);
 		return results;
+	}
+
+	/**
+	 * Detect newly created positions whose (expiration - created) is below the mini-lifetime threshold.
+	 * The WFPS forced-sale attack on 2026-04-25 used a clone with a 36-second lifetime — this would
+	 * fire a HIGH-severity alert ~5 minutes after such a clone is created.
+	 */
+	async checkMiniLifetimeClones(telegramService: TelegramService): Promise<void> {
+		const candidates = await this.positionRepo.findUnalertedMiniLifetime(MINI_LIFETIME_THRESHOLD_SECONDS);
+		if (candidates.length === 0) return;
+
+		const now = BigInt(Math.floor(Date.now() / 1000));
+		for (const c of candidates) {
+			const lifetime = c.expiration - c.created;
+			const principalDeuro = Number(BigInt(c.principal) / 10n ** 18n);
+			const message =
+				`Suspicious clone detected\n\n` +
+				`Position: \`${c.address}\`\n` +
+				`Owner: \`${c.owner}\`\n` +
+				`Collateral: \`${c.collateral}\`\n` +
+				`Lifetime: *${lifetime}s*  (threshold: ${MINI_LIFETIME_THRESHOLD_SECONDS}s)\n` +
+				`Principal: ${principalDeuro.toLocaleString()} dEURO\n\n` +
+				`This pattern matches the WFPS forced-sale attack vector (clone with sub-day lifetime, ` +
+				`waiting for decay to drain the equity reserve).\n\n` +
+				`Mitigation: open a challenge or call \`buyExpiredCollateral\` once the position enters phase 2.`;
+
+			await telegramService.sendCriticalAlert(message);
+			await this.positionRepo.markMiniLifetimeAlerted(c.address, now);
+			this.logger.warn(`Mini-lifetime alert sent for ${c.address} (lifetime=${lifetime}s)`);
+		}
+	}
+
+	/**
+	 * Detect open positions that are past their expiration with positive debt and have entered
+	 * phase 2 of the forced-sale decay (where price drops from 1× to 0× liq-price). Sends one
+	 * HIGH-severity alert per position via the dedup column phase2_alerted_at.
+	 */
+	async checkExpiredInPhase2(telegramService: TelegramService): Promise<void> {
+		const now = BigInt(Math.floor(Date.now() / 1000));
+		const expired = await this.positionRepo.findExpiredWithDebt(now);
+		if (expired.length === 0) return;
+
+		for (const p of expired) {
+			if (p.phase2AlertedAt !== null) continue; // already alerted
+
+			const timePassed = now - p.expiration;
+			if (timePassed < p.challengePeriod) continue; // still in phase 1 (price > liq)
+
+			// In phase 2 — useful arbitrage window
+			const principalDeuro = Number(BigInt(p.principal) / 10n ** 18n);
+			const decayPrice = BigInt(p.expiredPurchasePrice);
+			const liqPrice = BigInt(p.price);
+			const decayPct = liqPrice > 0n ? Number((decayPrice * 10000n) / liqPrice) / 100 : 0;
+			const phase2Pct = Number(((timePassed - p.challengePeriod) * 100n) / p.challengePeriod);
+
+			const message =
+				`Expired position in phase 2 (decay window open)\n\n` +
+				`Position: \`${p.address}\`\n` +
+				`Collateral: \`${p.collateral}\`\n` +
+				`Principal: ${principalDeuro.toLocaleString()} dEURO\n` +
+				`Time past expiration: ${timePassed}s  (challengePeriod: ${p.challengePeriod}s)\n` +
+				`Phase 2 progress: ${phase2Pct}% — price decays linearly from liq to 0\n` +
+				`Current decay price: ${decayPct.toFixed(2)}% of liq\n\n` +
+				`Without intervention, the equity reserve covers the gap between forced-sale ` +
+				`proceeds and outstanding principal. A defender can call ` +
+				`\`MintingHub.buyExpiredCollateral\` now to repay the debt at decay price.`;
+
+			await telegramService.sendCriticalAlert(message);
+			await this.positionRepo.markPhase2Alerted(p.address, now);
+			this.logger.warn(`Phase-2 alert sent for ${p.address} (timePassed=${timePassed}s)`);
+		}
 	}
 }

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -11,6 +11,9 @@ import { TelegramService } from './telegram.service';
 // Anything below is suspicious for a clone — the WFPS attacker used a 36-second clone.
 const MINI_LIFETIME_THRESHOLD_SECONDS = 86_400n; // 1 day
 const EXPIRING_SOON_WINDOW_SECONDS = 86_400n; // 24 h heads-up before expiration
+const TELEGRAM_THROTTLE_MS = 100; // stay under per-chat rate limit (~30 msg/s) when bursting
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 @Injectable()
 export class PositionService {
@@ -171,13 +174,13 @@ export class PositionService {
 				`Mitigation: open a challenge or call \`buyExpiredCollateral\` once the position enters phase 2.\n\n` +
 				`[Etherscan](https://etherscan.io/address/${c.address})`;
 
-			try {
-				await telegramService.sendCriticalAlert(message);
+			const delivered = await telegramService.sendCriticalAlert(message);
+			if (delivered) {
 				await this.positionRepo.markMiniLifetimeAlerted(c.address, now);
 				this.logger.warn(`Mini-lifetime alert sent for ${c.address} (lifetime=${lifetime}s)`);
-			} catch (error) {
-				this.logger.error(`Failed to send mini-lifetime alert for ${c.address}: ${error?.message}`);
 			}
+			// On delivery failure: do not mark — next cycle will retry.
+			await sleep(TELEGRAM_THROTTLE_MS);
 		}
 	}
 
@@ -205,13 +208,12 @@ export class PositionService {
 				`phase 2 (after one challenge period) if needed.\n\n` +
 				`[Etherscan](https://etherscan.io/address/${c.address})`;
 
-			try {
-				await telegramService.sendCriticalAlert(message);
+			const delivered = await telegramService.sendCriticalAlert(message);
+			if (delivered) {
 				await this.positionRepo.markExpiringSoonAlerted(c.address, now);
 				this.logger.warn(`Expiring-soon alert sent for ${c.address}`);
-			} catch (error) {
-				this.logger.error(`Failed to send expiring-soon alert for ${c.address}: ${error?.message}`);
 			}
+			await sleep(TELEGRAM_THROTTLE_MS);
 		}
 	}
 
@@ -251,13 +253,12 @@ export class PositionService {
 				`A defender can call \`MintingHub.buyExpiredCollateral\` to repay the debt at decay price.\n\n` +
 				`[Etherscan](https://etherscan.io/address/${p.address})`;
 
-			try {
-				await telegramService.sendCriticalAlert(message);
+			const delivered = await telegramService.sendCriticalAlert(message);
+			if (delivered) {
 				await this.positionRepo.markExpiredAlerted(p.address, now);
 				this.logger.warn(`Expired alert sent for ${p.address}`);
-			} catch (error) {
-				this.logger.error(`Failed to send expired alert for ${p.address}: ${error?.message}`);
 			}
+			await sleep(TELEGRAM_THROTTLE_MS);
 		}
 	}
 
@@ -299,13 +300,12 @@ export class PositionService {
 				`\`MintingHub.buyExpiredCollateral\` now to repay the debt at decay price.\n\n` +
 				`[Etherscan](https://etherscan.io/address/${p.address})`;
 
-			try {
-				await telegramService.sendCriticalAlert(message);
+			const delivered = await telegramService.sendCriticalAlert(message);
+			if (delivered) {
 				await this.positionRepo.markPhase2Alerted(p.address, now);
 				this.logger.warn(`Phase-2 alert sent for ${p.address} (timePassed=${timePassed}s)`);
-			} catch (error) {
-				this.logger.error(`Failed to send phase-2 alert for ${p.address}: ${error?.message}`);
 			}
+			await sleep(TELEGRAM_THROTTLE_MS);
 		}
 	}
 }

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -157,21 +157,26 @@ export class PositionService {
 		const now = BigInt(Math.floor(Date.now() / 1000));
 		for (const c of candidates) {
 			const lifetime = c.expiration - c.created;
-			const principalDeuro = Number(BigInt(c.principal) / 10n ** 18n);
+			const principalDeuro = formatDeuro(c.principal);
 			const message =
 				`Suspicious clone detected\n\n` +
 				`Position: \`${c.address}\`\n` +
 				`Owner: \`${c.owner}\`\n` +
 				`Collateral: \`${c.collateral}\`\n` +
 				`Lifetime: *${lifetime}s*  (threshold: ${MINI_LIFETIME_THRESHOLD_SECONDS}s)\n` +
-				`Principal: ${principalDeuro.toLocaleString()} dEURO\n\n` +
+				`Principal: ${principalDeuro} dEURO\n\n` +
 				`This pattern matches the WFPS forced-sale attack vector (clone with sub-day lifetime, ` +
 				`waiting for decay to drain the equity reserve).\n\n` +
-				`Mitigation: open a challenge or call \`buyExpiredCollateral\` once the position enters phase 2.`;
+				`Mitigation: open a challenge or call \`buyExpiredCollateral\` once the position enters phase 2.\n\n` +
+				`[Etherscan](https://etherscan.io/address/${c.address})`;
 
-			await telegramService.sendCriticalAlert(message);
-			await this.positionRepo.markMiniLifetimeAlerted(c.address, now);
-			this.logger.warn(`Mini-lifetime alert sent for ${c.address} (lifetime=${lifetime}s)`);
+			try {
+				await telegramService.sendCriticalAlert(message);
+				await this.positionRepo.markMiniLifetimeAlerted(c.address, now);
+				this.logger.warn(`Mini-lifetime alert sent for ${c.address} (lifetime=${lifetime}s)`);
+			} catch (error) {
+				this.logger.error(`Failed to send mini-lifetime alert for ${c.address}: ${error?.message}`);
+			}
 		}
 	}
 
@@ -187,32 +192,45 @@ export class PositionService {
 
 		for (const p of expired) {
 			if (p.phase2AlertedAt !== null) continue; // already alerted
-
 			const timePassed = now - p.expiration;
 			if (timePassed < p.challengePeriod) continue; // still in phase 1 (price > liq)
 
-			// In phase 2 — useful arbitrage window
-			const principalDeuro = Number(BigInt(p.principal) / 10n ** 18n);
+			// In phase 2 — useful arbitrage window. Clamp progress at 100% in case the cycle
+			// runs after both decay phases have fully elapsed (decay price = 0).
+			const principalDeuro = formatDeuro(p.principal);
 			const decayPrice = BigInt(p.expiredPurchasePrice);
 			const liqPrice = BigInt(p.price);
 			const decayPct = liqPrice > 0n ? Number((decayPrice * 10000n) / liqPrice) / 100 : 0;
-			const phase2Pct = Number(((timePassed - p.challengePeriod) * 100n) / p.challengePeriod);
+			const rawPhase2Pct = Number(((timePassed - p.challengePeriod) * 100n) / p.challengePeriod);
+			const phase2Pct = Math.min(rawPhase2Pct, 100);
+			const phaseLabel = rawPhase2Pct >= 100 ? 'phase 2 complete (decay reached 0)' : `phase 2 progress: ${phase2Pct}%`;
 
 			const message =
-				`Expired position in phase 2 (decay window open)\n\n` +
+				`Expired position in forced-sale decay\n\n` +
 				`Position: \`${p.address}\`\n` +
 				`Collateral: \`${p.collateral}\`\n` +
-				`Principal: ${principalDeuro.toLocaleString()} dEURO\n` +
+				`Principal: ${principalDeuro} dEURO\n` +
 				`Time past expiration: ${timePassed}s  (challengePeriod: ${p.challengePeriod}s)\n` +
-				`Phase 2 progress: ${phase2Pct}% — price decays linearly from liq to 0\n` +
+				`${phaseLabel} — price decays linearly from liq to 0\n` +
 				`Current decay price: ${decayPct.toFixed(2)}% of liq\n\n` +
 				`Without intervention, the equity reserve covers the gap between forced-sale ` +
 				`proceeds and outstanding principal. A defender can call ` +
-				`\`MintingHub.buyExpiredCollateral\` now to repay the debt at decay price.`;
+				`\`MintingHub.buyExpiredCollateral\` now to repay the debt at decay price.\n\n` +
+				`[Etherscan](https://etherscan.io/address/${p.address})`;
 
-			await telegramService.sendCriticalAlert(message);
-			await this.positionRepo.markPhase2Alerted(p.address, now);
-			this.logger.warn(`Phase-2 alert sent for ${p.address} (timePassed=${timePassed}s)`);
+			try {
+				await telegramService.sendCriticalAlert(message);
+				await this.positionRepo.markPhase2Alerted(p.address, now);
+				this.logger.warn(`Phase-2 alert sent for ${p.address} (timePassed=${timePassed}s)`);
+			} catch (error) {
+				this.logger.error(`Failed to send phase-2 alert for ${p.address}: ${error?.message}`);
+			}
 		}
 	}
+}
+
+/** Format an 18-decimal dEURO principal string with two decimal places and locale separators. */
+function formatDeuro(principalRaw: string): string {
+	const cents = BigInt(principalRaw) / 10n ** 16n;
+	return (Number(cents) / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -282,6 +282,7 @@ export class PositionService {
 			const message =
 				`Expired position in forced-sale decay\n\n` +
 				`Position: \`${p.address}\`\n` +
+				`Owner: \`${p.owner}\`\n` +
 				`Collateral: \`${p.collateral}\`\n` +
 				`Principal: ${principalDeuro} dEURO\n` +
 				`Time past expiration: ${timePassed}s  (challengePeriod: ${p.challengePeriod}s)\n` +

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -64,7 +64,6 @@ export class PositionService {
 			// Fixed fields
 			if (isNew) {
 				calls.push(() => position.limit());
-				calls.push(() => position.owner());
 				calls.push(() => position.original());
 				calls.push(() => position.collateral());
 				calls.push(() => position.minimumCollateral());
@@ -75,7 +74,8 @@ export class PositionService {
 				calls.push(() => position.expiration());
 			}
 
-			// Dynamic fields
+			// Dynamic fields (owner is here because it can change via transferOwnership)
+			calls.push(() => position.owner());
 			calls.push(() => position.price());
 			calls.push(() => position.virtualPrice());
 			calls.push(() => position.getCollateralRequirement());
@@ -109,7 +109,6 @@ export class PositionService {
 			if (isNew) {
 				// Fixed fields
 				state.limit = BigInt(responses[idx++]);
-				state.owner = responses[idx++];
 				state.original = responses[idx++];
 				state.collateral = responses[idx++];
 				state.minimumCollateral = BigInt(responses[idx++]);
@@ -121,7 +120,8 @@ export class PositionService {
 				state.created = event.timestamp;
 			}
 
-			// Dynamic fields
+			// Dynamic fields (owner can change via transferOwnership; sync every cycle)
+			state.owner = responses[idx++];
 			state.price = BigInt(responses[idx++]);
 			state.virtualPrice = BigInt(responses[idx++]);
 			state.collateralRequirement = BigInt(responses[idx++]);
@@ -225,6 +225,13 @@ export class PositionService {
 		if (expired.length === 0) return;
 
 		for (const p of expired) {
+			// If a position is first seen already in phase 2 (e.g. service was down longer
+			// than one challengePeriod past expiration), skip the expired alert — the phase-2
+			// watcher fires in the same cycle with more actionable info.
+			if (now - p.expiration >= p.challengePeriod) {
+				await this.positionRepo.markExpiredAlerted(p.address, now);
+				continue;
+			}
 			const principalDeuro = formatDeuro(p.principal);
 			const begin = new Date(Number(p.expiration) * 1000);
 			const phase2Start = new Date(Number(p.expiration + p.challengePeriod) * 1000);

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -261,11 +261,10 @@ export class PositionService {
 	 */
 	async checkExpiredInPhase2(telegramService: TelegramService): Promise<void> {
 		const now = BigInt(Math.floor(Date.now() / 1000));
-		const expired = await this.positionRepo.findExpiredWithDebt(now);
-		if (expired.length === 0) return;
+		const candidates = await this.positionRepo.findUnalertedPhase2(now);
+		if (candidates.length === 0) return;
 
-		for (const p of expired) {
-			if (p.phase2AlertedAt !== null) continue; // already alerted
+		for (const p of candidates) {
 			const timePassed = now - p.expiration;
 			if (timePassed < p.challengePeriod) continue; // still in phase 1 (price > liq)
 

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -10,6 +10,7 @@ import { TelegramService } from './telegram.service';
 
 // Anything below is suspicious for a clone — the WFPS attacker used a 36-second clone.
 const MINI_LIFETIME_THRESHOLD_SECONDS = 86_400n; // 1 day
+const EXPIRING_SOON_WINDOW_SECONDS = 86_400n; // 24 h heads-up before expiration
 
 @Injectable()
 export class PositionService {
@@ -176,6 +177,79 @@ export class PositionService {
 				this.logger.warn(`Mini-lifetime alert sent for ${c.address} (lifetime=${lifetime}s)`);
 			} catch (error) {
 				this.logger.error(`Failed to send mini-lifetime alert for ${c.address}: ${error?.message}`);
+			}
+		}
+	}
+
+	/**
+	 * Detect open positions whose expiration is within the next EXPIRING_SOON_WINDOW. One alert
+	 * per position via expiring_soon_alerted_at.
+	 */
+	async checkExpiringSoon(telegramService: TelegramService): Promise<void> {
+		const now = BigInt(Math.floor(Date.now() / 1000));
+		const candidates = await this.positionRepo.findUnalertedExpiringSoon(now + EXPIRING_SOON_WINDOW_SECONDS);
+		if (candidates.length === 0) return;
+
+		for (const c of candidates) {
+			const principalDeuro = formatDeuro(c.principal);
+			const hoursToExpiration = Number(c.expiration - now) / 3600;
+			const message =
+				`Position will expire soon\n\n` +
+				`Position: \`${c.address}\`\n` +
+				`Owner: \`${c.owner}\`\n` +
+				`Collateral: \`${c.collateral}\`\n` +
+				`Principal: ${principalDeuro} dEURO\n` +
+				`Expires in: ${hoursToExpiration.toFixed(1)} hours\n` +
+				`Challenge period: ${Number(c.challengePeriod) / 3600} hours\n\n` +
+				`Forced-sale window opens at expiration. Plan to monitor and intervene during ` +
+				`phase 2 (after one challenge period) if needed.\n\n` +
+				`[Etherscan](https://etherscan.io/address/${c.address})`;
+
+			try {
+				await telegramService.sendCriticalAlert(message);
+				await this.positionRepo.markExpiringSoonAlerted(c.address, now);
+				this.logger.warn(`Expiring-soon alert sent for ${c.address}`);
+			} catch (error) {
+				this.logger.error(`Failed to send expiring-soon alert for ${c.address}: ${error?.message}`);
+			}
+		}
+	}
+
+	/**
+	 * Detect open positions that just transitioned past expiration with positive debt. Fires once
+	 * per position via expired_alerted_at; the phase-2 watcher takes over after one challenge period.
+	 */
+	async checkExpired(telegramService: TelegramService): Promise<void> {
+		const now = BigInt(Math.floor(Date.now() / 1000));
+		const expired = await this.positionRepo.findUnalertedExpired(now);
+		if (expired.length === 0) return;
+
+		for (const p of expired) {
+			const principalDeuro = formatDeuro(p.principal);
+			const begin = new Date(Number(p.expiration) * 1000);
+			const phase2Start = new Date(Number(p.expiration + p.challengePeriod) * 1000);
+			const decayEnd = new Date(Number(p.expiration + p.challengePeriod * 2n) * 1000);
+
+			const message =
+				`Position is expired — forced-sale window open\n\n` +
+				`Position: \`${p.address}\`\n` +
+				`Owner: \`${p.owner}\`\n` +
+				`Collateral: \`${p.collateral}\`\n` +
+				`Principal: ${principalDeuro} dEURO\n\n` +
+				`Decay schedule (\`expiredPurchasePrice\`):\n` +
+				`• 10× → 1× liq-price: ${begin.toUTCString()}\n` +
+				`• 1× → 0× liq-price:  ${phase2Start.toUTCString()}\n` +
+				`• Reaches zero:        ${decayEnd.toUTCString()}\n\n` +
+				`Phase 2 (1× → 0×) is the actionable arbitrage window. ` +
+				`A defender can call \`MintingHub.buyExpiredCollateral\` to repay the debt at decay price.\n\n` +
+				`[Etherscan](https://etherscan.io/address/${p.address})`;
+
+			try {
+				await telegramService.sendCriticalAlert(message);
+				await this.positionRepo.markExpiredAlerted(p.address, now);
+				this.logger.warn(`Expired alert sent for ${p.address}`);
+			} catch (error) {
+				this.logger.error(`Failed to send expired alert for ${p.address}: ${error?.message}`);
 			}
 		}
 	}

--- a/src/monitoringV2/prisma/migrations/0003_position_alert_dedup/migration.sql
+++ b/src/monitoringV2/prisma/migrations/0003_position_alert_dedup/migration.sql
@@ -1,0 +1,4 @@
+-- Track when alerts were sent to avoid re-sending every cycle
+ALTER TABLE "position_states"
+  ADD COLUMN "mini_lifetime_alerted_at" BIGINT,
+  ADD COLUMN "phase2_alerted_at"        BIGINT;

--- a/src/monitoringV2/prisma/migrations/0003_position_alert_dedup/migration.sql
+++ b/src/monitoringV2/prisma/migrations/0003_position_alert_dedup/migration.sql
@@ -1,4 +1,6 @@
 -- Track when alerts were sent to avoid re-sending every cycle
 ALTER TABLE "position_states"
-  ADD COLUMN "mini_lifetime_alerted_at" BIGINT,
-  ADD COLUMN "phase2_alerted_at"        BIGINT;
+  ADD COLUMN "mini_lifetime_alerted_at"  BIGINT,
+  ADD COLUMN "expiring_soon_alerted_at" BIGINT,
+  ADD COLUMN "expired_alerted_at"        BIGINT,
+  ADD COLUMN "phase2_alerted_at"         BIGINT;

--- a/src/monitoringV2/prisma/repositories/position.repository.ts
+++ b/src/monitoringV2/prisma/repositories/position.repository.ts
@@ -169,4 +169,104 @@ export class PositionRepository {
 
 		return BigInt(result._sum.interest?.toFixed(0) || '0');
 	}
+
+	async findExpiredWithDebt(now: bigint): Promise<
+		Array<{
+			address: string;
+			expiration: bigint;
+			challengePeriod: bigint;
+			principal: string;
+			collateral: string;
+			collateralAmount: string;
+			price: string;
+			expiredPurchasePrice: string;
+			phase2AlertedAt: bigint | null;
+		}>
+	> {
+		const rows = await this.prisma.positionState.findMany({
+			where: {
+				isClosed: false,
+				isDenied: false,
+				expiration: { lt: now },
+			},
+			select: {
+				address: true,
+				expiration: true,
+				challengePeriod: true,
+				principal: true,
+				collateral: true,
+				collateralAmount: true,
+				price: true,
+				expiredPurchasePrice: true,
+				phase2AlertedAt: true,
+			},
+		});
+		// Filter principal>0 in JS (Prisma Decimal comparison via raw value)
+		return rows
+			.filter((r) => BigInt(r.principal.toFixed(0)) > 0n)
+			.map((r) => ({
+				address: r.address,
+				expiration: r.expiration,
+				challengePeriod: r.challengePeriod,
+				principal: r.principal.toFixed(0),
+				collateral: r.collateral,
+				collateralAmount: r.collateralAmount.toFixed(0),
+				price: r.price.toFixed(0),
+				expiredPurchasePrice: r.expiredPurchasePrice.toFixed(0),
+				phase2AlertedAt: r.phase2AlertedAt,
+			}));
+	}
+
+	async findUnalertedMiniLifetime(thresholdSeconds: bigint): Promise<
+		Array<{
+			address: string;
+			created: bigint;
+			expiration: bigint;
+			principal: string;
+			collateral: string;
+			owner: string;
+		}>
+	> {
+		const rows = await this.prisma.positionState.findMany({
+			where: {
+				miniLifetimeAlertedAt: null,
+				isClosed: false,
+				isDenied: false,
+				// expiration - created < threshold expressed as expiration < created + threshold
+				// Prisma can't subtract two columns; we filter in JS below
+			},
+			select: {
+				address: true,
+				created: true,
+				expiration: true,
+				principal: true,
+				collateral: true,
+				owner: true,
+			},
+		});
+		return rows
+			.filter((r) => r.expiration - r.created < thresholdSeconds)
+			.map((r) => ({
+				address: r.address,
+				created: r.created,
+				expiration: r.expiration,
+				principal: r.principal.toFixed(0),
+				collateral: r.collateral,
+				owner: r.owner,
+			}));
+	}
+
+	async markPhase2Alerted(address: string, timestamp: bigint): Promise<void> {
+		await this.prisma.positionState.update({
+			where: { address: address.toLowerCase() },
+			data: { phase2AlertedAt: timestamp },
+		});
+	}
+
+	async markMiniLifetimeAlerted(address: string, timestamp: bigint): Promise<void> {
+		await this.prisma.positionState.update({
+			where: { address: address.toLowerCase() },
+			data: { miniLifetimeAlertedAt: timestamp },
+		});
+	}
 }

--- a/src/monitoringV2/prisma/repositories/position.repository.ts
+++ b/src/monitoringV2/prisma/repositories/position.repository.ts
@@ -188,6 +188,7 @@ export class PositionRepository {
 				isClosed: false,
 				isDenied: false,
 				expiration: { lt: now },
+				principal: { gt: 0 },
 			},
 			select: {
 				address: true,
@@ -201,20 +202,17 @@ export class PositionRepository {
 				phase2AlertedAt: true,
 			},
 		});
-		// Filter principal>0 in JS (Prisma Decimal comparison via raw value)
-		return rows
-			.filter((r) => BigInt(r.principal.toFixed(0)) > 0n)
-			.map((r) => ({
-				address: r.address,
-				expiration: r.expiration,
-				challengePeriod: r.challengePeriod,
-				principal: r.principal.toFixed(0),
-				collateral: r.collateral,
-				collateralAmount: r.collateralAmount.toFixed(0),
-				price: r.price.toFixed(0),
-				expiredPurchasePrice: r.expiredPurchasePrice.toFixed(0),
-				phase2AlertedAt: r.phase2AlertedAt,
-			}));
+		return rows.map((r) => ({
+			address: r.address,
+			expiration: r.expiration,
+			challengePeriod: r.challengePeriod,
+			principal: r.principal.toFixed(0),
+			collateral: r.collateral,
+			collateralAmount: r.collateralAmount.toFixed(0),
+			price: r.price.toFixed(0),
+			expiredPurchasePrice: r.expiredPurchasePrice.toFixed(0),
+			phase2AlertedAt: r.phase2AlertedAt,
+		}));
 	}
 
 	async findUnalertedMiniLifetime(thresholdSeconds: bigint): Promise<

--- a/src/monitoringV2/prisma/repositories/position.repository.ts
+++ b/src/monitoringV2/prisma/repositories/position.repository.ts
@@ -173,6 +173,7 @@ export class PositionRepository {
 	async findExpiredWithDebt(now: bigint): Promise<
 		Array<{
 			address: string;
+			owner: string;
 			expiration: bigint;
 			challengePeriod: bigint;
 			principal: string;
@@ -192,6 +193,7 @@ export class PositionRepository {
 			},
 			select: {
 				address: true,
+				owner: true,
 				expiration: true,
 				challengePeriod: true,
 				principal: true,
@@ -204,6 +206,7 @@ export class PositionRepository {
 		});
 		return rows.map((r) => ({
 			address: r.address,
+			owner: r.owner,
 			expiration: r.expiration,
 			challengePeriod: r.challengePeriod,
 			principal: r.principal.toFixed(0),

--- a/src/monitoringV2/prisma/repositories/position.repository.ts
+++ b/src/monitoringV2/prisma/repositories/position.repository.ts
@@ -254,6 +254,83 @@ export class PositionRepository {
 			}));
 	}
 
+	async findUnalertedExpiringSoon(thresholdNowPlus: bigint): Promise<
+		Array<{
+			address: string;
+			expiration: bigint;
+			challengePeriod: bigint;
+			principal: string;
+			collateral: string;
+			owner: string;
+		}>
+	> {
+		const now = BigInt(Math.floor(Date.now() / 1000));
+		const rows = await this.prisma.positionState.findMany({
+			where: {
+				expiringSoonAlertedAt: null,
+				isClosed: false,
+				isDenied: false,
+				expiration: { gte: now, lt: thresholdNowPlus },
+			},
+			select: {
+				address: true,
+				expiration: true,
+				challengePeriod: true,
+				principal: true,
+				collateral: true,
+				owner: true,
+			},
+		});
+		return rows.map((r) => ({
+			address: r.address,
+			expiration: r.expiration,
+			challengePeriod: r.challengePeriod,
+			principal: r.principal.toFixed(0),
+			collateral: r.collateral,
+			owner: r.owner,
+		}));
+	}
+
+	async findUnalertedExpired(now: bigint): Promise<
+		Array<{
+			address: string;
+			expiration: bigint;
+			challengePeriod: bigint;
+			principal: string;
+			collateral: string;
+			price: string;
+			owner: string;
+		}>
+	> {
+		const rows = await this.prisma.positionState.findMany({
+			where: {
+				expiredAlertedAt: null,
+				isClosed: false,
+				isDenied: false,
+				expiration: { lt: now },
+				principal: { gt: 0 },
+			},
+			select: {
+				address: true,
+				expiration: true,
+				challengePeriod: true,
+				principal: true,
+				collateral: true,
+				price: true,
+				owner: true,
+			},
+		});
+		return rows.map((r) => ({
+			address: r.address,
+			expiration: r.expiration,
+			challengePeriod: r.challengePeriod,
+			principal: r.principal.toFixed(0),
+			collateral: r.collateral,
+			price: r.price.toFixed(0),
+			owner: r.owner,
+		}));
+	}
+
 	async markPhase2Alerted(address: string, timestamp: bigint): Promise<void> {
 		await this.prisma.positionState.update({
 			where: { address: address.toLowerCase() },
@@ -265,6 +342,20 @@ export class PositionRepository {
 		await this.prisma.positionState.update({
 			where: { address: address.toLowerCase() },
 			data: { miniLifetimeAlertedAt: timestamp },
+		});
+	}
+
+	async markExpiringSoonAlerted(address: string, timestamp: bigint): Promise<void> {
+		await this.prisma.positionState.update({
+			where: { address: address.toLowerCase() },
+			data: { expiringSoonAlertedAt: timestamp },
+		});
+	}
+
+	async markExpiredAlerted(address: string, timestamp: bigint): Promise<void> {
+		await this.prisma.positionState.update({
+			where: { address: address.toLowerCase() },
+			data: { expiredAlertedAt: timestamp },
 		});
 	}
 }

--- a/src/monitoringV2/prisma/repositories/position.repository.ts
+++ b/src/monitoringV2/prisma/repositories/position.repository.ts
@@ -60,6 +60,7 @@ export class PositionRepository {
 				this.prisma.positionState.update({
 					where: { address: p.address!.toLowerCase() },
 					data: {
+						owner: p.owner!.toLowerCase(),
 						price: p.price!.toString(),
 						virtualPrice: p.virtualPrice!.toString(),
 						collateralAmount: p.collateralAmount!.toString(),

--- a/src/monitoringV2/prisma/repositories/position.repository.ts
+++ b/src/monitoringV2/prisma/repositories/position.repository.ts
@@ -170,7 +170,7 @@ export class PositionRepository {
 		return BigInt(result._sum.interest?.toFixed(0) || '0');
 	}
 
-	async findExpiredWithDebt(now: bigint): Promise<
+	async findUnalertedPhase2(now: bigint): Promise<
 		Array<{
 			address: string;
 			owner: string;
@@ -181,15 +181,17 @@ export class PositionRepository {
 			collateralAmount: string;
 			price: string;
 			expiredPurchasePrice: string;
-			phase2AlertedAt: bigint | null;
 		}>
 	> {
 		const rows = await this.prisma.positionState.findMany({
 			where: {
+				phase2AlertedAt: null,
 				isClosed: false,
 				isDenied: false,
 				expiration: { lt: now },
 				principal: { gt: 0 },
+				// Phase-2 condition (now - expiration >= challengePeriod) cannot be expressed as
+				// a Prisma column-column comparison; the service-side caller filters that.
 			},
 			select: {
 				address: true,
@@ -201,7 +203,6 @@ export class PositionRepository {
 				collateralAmount: true,
 				price: true,
 				expiredPurchasePrice: true,
-				phase2AlertedAt: true,
 			},
 		});
 		return rows.map((r) => ({
@@ -214,7 +215,6 @@ export class PositionRepository {
 			collateralAmount: r.collateralAmount.toFixed(0),
 			price: r.price.toFixed(0),
 			expiredPurchasePrice: r.expiredPurchasePrice.toFixed(0),
-			phase2AlertedAt: r.phase2AlertedAt,
 		}));
 	}
 

--- a/src/monitoringV2/prisma/schema.prisma
+++ b/src/monitoringV2/prisma/schema.prisma
@@ -96,8 +96,10 @@ model PositionState {
   isDenied              Boolean @default(false) @map("is_denied")
 
   // Alert dedup: timestamps of last sent alerts to avoid spam across cycles
-  miniLifetimeAlertedAt BigInt? @map("mini_lifetime_alerted_at") // Unix seconds
-  phase2AlertedAt       BigInt? @map("phase2_alerted_at") // Unix seconds
+  miniLifetimeAlertedAt  BigInt? @map("mini_lifetime_alerted_at") // Unix seconds
+  expiringSoonAlertedAt  BigInt? @map("expiring_soon_alerted_at") // Unix seconds
+  expiredAlertedAt       BigInt? @map("expired_alerted_at") // Unix seconds
+  phase2AlertedAt        BigInt? @map("phase2_alerted_at") // Unix seconds
 
   // Metadata
   timestamp DateTime @db.Timestamptz

--- a/src/monitoringV2/prisma/schema.prisma
+++ b/src/monitoringV2/prisma/schema.prisma
@@ -95,6 +95,10 @@ model PositionState {
   isClosed              Boolean @map("is_closed")
   isDenied              Boolean @default(false) @map("is_denied")
 
+  // Alert dedup: timestamps of last sent alerts to avoid spam across cycles
+  miniLifetimeAlertedAt BigInt? @map("mini_lifetime_alerted_at") // Unix seconds
+  phase2AlertedAt       BigInt? @map("phase2_alerted_at") // Unix seconds
+
   // Metadata
   timestamp DateTime @db.Timestamptz
 

--- a/src/monitoringV2/telegram.service.ts
+++ b/src/monitoringV2/telegram.service.ts
@@ -138,15 +138,22 @@ export class TelegramService {
 		return lines.join('\n');
 	}
 
-	async sendCriticalAlert(message: string): Promise<void> {
-		if (!this.enabled) return;
+	/**
+	 * Send a critical alert. Returns true if delivered (or telegram disabled — nothing to
+	 * deliver to). Returns false on Telegram API failure (429, network drop, parse error)
+	 * so callers can skip persisting "alerted" state and retry next cycle.
+	 */
+	async sendCriticalAlert(message: string): Promise<boolean> {
+		if (!this.enabled) return true;
 
 		try {
 			const formattedMessage = `🚨 *CRITICAL ALERT*\n\n${message}\n\n_Timestamp: ${new Date().toISOString()}_`;
 			await this.sendMessage(formattedMessage);
 			this.logger.log('Critical alert sent via Telegram');
+			return true;
 		} catch (error) {
 			this.logger.error(`Failed to send critical Telegram alert: ${error.message}`);
+			return false;
 		}
 	}
 

--- a/src/monitoringV2/telegram.service.ts
+++ b/src/monitoringV2/telegram.service.ts
@@ -139,12 +139,17 @@ export class TelegramService {
 	}
 
 	/**
-	 * Send a critical alert. Returns true if delivered (or telegram disabled — nothing to
-	 * deliver to). Returns false on Telegram API failure (429, network drop, parse error)
-	 * so callers can skip persisting "alerted" state and retry next cycle.
+	 * Send a critical alert. Returns true only on confirmed delivery. Returns false when
+	 * telegram is disabled (config / token rotation) or on Telegram API failure (429,
+	 * network drop, parse error) so callers do not persist "alerted" state. This way an
+	 * outage / disabled period does not silently drop alerts: positions stay unalerted
+	 * in the DB and are retried every cycle until delivery succeeds.
+	 *
+	 * The trade-off is some log volume while telegram is disabled, but disabled is
+	 * expected to be a configuration/operator state, not the steady state.
 	 */
 	async sendCriticalAlert(message: string): Promise<boolean> {
-		if (!this.enabled) return true;
+		if (!this.enabled) return false;
 
 		try {
 			const formattedMessage = `🚨 *CRITICAL ALERT*\n\n${message}\n\n_Timestamp: ${new Date().toISOString()}_`;


### PR DESCRIPTION
## Summary

Closes the monitoring gap that allowed the WFPS forced-sale attack on **2026-04-25** to drain ~4 621 dEURO from the equity reserve unobserved for 46 hours.

The current monitoring is fully event-driven. The decay between a clone's expiration and its drain is a **passive state transition** (no event), so no alert fires until the loss is already realized via `ForcedSale`/`Loss`/`MintingUpdate` — too late.

## What this adds

Two cycle-time watchers in `MonitoringService.processBlocks()`, run once per 5-minute cycle after position state sync:

### 1. `checkMiniLifetimeClones`
Flags newly synced positions whose `expiration - created < 1 day`. The attacker's clone had a **36-second lifetime** — a single HIGH-severity Telegram alert per such position would have surfaced the setup well before phase 2.

Alert content: position address, owner, collateral, lifetime in seconds, principal in dEURO, mitigation hint.

### 2. `checkExpiredInPhase2`
Flags open positions past their expiration with `principal > 0` that have entered **phase 2** of the decay curve (`timePassed >= challengePeriod`). This is the ~24-hour arbitrage window where a defender can still call `MintingHub.buyExpiredCollateral` and repay the debt at decay price before the equity reserve absorbs the gap.

Alert content: position, collateral, principal, time past expiration, phase-2 progress %, current decay price as % of liq-price, action hint.

### 3. `Loss` severity bump
`Loss` events were `MEDIUM`. A realized hit on the equity reserve is material — bumped to `HIGH`.

## Dedup

Both watchers persist alert-sent timestamps to avoid spamming every 5 minutes:

- `position_states.mini_lifetime_alerted_at` — Unix seconds
- `position_states.phase2_alerted_at` — Unix seconds

Migration `0003_position_alert_dedup` adds both nullable columns.

## Test plan

- [ ] `npm run prisma:generate && npm run build` — verified clean locally
- [ ] Apply migration on dev DB (`node src/monitoringV2/prisma/migrate.js`)
- [ ] Confirm next monitoring cycle issues no spurious alerts (existing positions are all >1 day lifetime and not expired)
- [ ] Sanity check: temporarily lower `MINI_LIFETIME_THRESHOLD_SECONDS` to ~30 days on dev → expect alerts for any clone shorter than that → revert
- [ ] Verify dedup: run 2 cycles in a row → only first should fire alert per position
- [ ] Production rollout: deploy to dev first, watch logs for one full cycle, then promote to main

## Out of scope

- Defender bot that actually calls `buyExpiredCollateral` — this PR only alerts.
- Min-Lifetime check in `MintingHub.clone()` itself — that's a smart-contract change, separate concern.
- WFPS-family-wide review and challenges against the attacker follow-on position `0x7EC6F1948…` — separate operational task.