### PR TITLE
Resolve monitoring upstream at request time (fix recreate-induced 502)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,10 +1,14 @@
 # nginx configuration for monitoring frontend
 
-# Use Docker's embedded DNS at runtime instead of caching the upstream IP at boot.
-# Without this, an `ip` change of `deuro-monitoring` (e.g. compose `up` recreates
-# the container) leaves nginx pointing at the stale IP and every /api request
-# returns 502 until nginx itself is restarted. The `valid=10s` re-resolves
-# every 10 seconds, so a recreated upstream is picked up automatically.
+# Use Docker's embedded DNS resolver at request time, with a 10-second cache.
+# Without this, nginx resolves the upstream hostname once at boot and caches the
+# IP forever. When `docker compose up` recreates the deuro-monitoring container
+# it gets a new IP, and every /api request from this proxy then 502s on
+# "connection refused" until nginx itself is restarted. The `valid=10s` window
+# means a recreated upstream is picked up automatically within 10 seconds.
+#
+# IPv6 is disabled because Docker's embedded DNS does not return AAAA records
+# in the default bridge network and nginx would log warnings on every miss.
 resolver 127.0.0.11 ipv6=off valid=10s;
 
 server {
@@ -12,11 +16,15 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # API reverse proxy to monitoring backend (strip /api prefix).
-    # Using a variable for the upstream forces nginx to resolve the hostname at
-    # request time via the resolver above, rather than caching it at startup.
+    # Using a variable in proxy_pass forces nginx to re-resolve via the resolver
+    # above at request time, rather than caching the static name at boot. The
+    # value is identical across the two proxy locations below.
+    set $monitoring_upstream "deuro-monitoring";
+
+    # API reverse proxy to monitoring backend. The rewrite strips the /api
+    # prefix; once proxy_pass uses a variable nginx no longer auto-strips
+    # the location prefix from the upstream URI, so we do it explicitly.
     location /api/ {
-        set $monitoring_upstream "deuro-monitoring";
         rewrite ^/api/(.*)$ /$1 break;
         proxy_pass http://$monitoring_upstream:3000;
         proxy_set_header Host $host;
@@ -27,7 +35,6 @@ server {
 
     # Swagger docs reverse proxy
     location /swagger {
-        set $monitoring_upstream "deuro-monitoring";
         proxy_pass http://$monitoring_upstream:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,12 +1,24 @@
 # nginx configuration for monitoring frontend
+
+# Use Docker's embedded DNS at runtime instead of caching the upstream IP at boot.
+# Without this, an `ip` change of `deuro-monitoring` (e.g. compose `up` recreates
+# the container) leaves nginx pointing at the stale IP and every /api request
+# returns 502 until nginx itself is restarted. The `valid=10s` re-resolves
+# every 10 seconds, so a recreated upstream is picked up automatically.
+resolver 127.0.0.11 ipv6=off valid=10s;
+
 server {
     listen 80;
     root /usr/share/nginx/html;
     index index.html;
 
-    # API reverse proxy to monitoring backend (strip /api prefix)
+    # API reverse proxy to monitoring backend (strip /api prefix).
+    # Using a variable for the upstream forces nginx to resolve the hostname at
+    # request time via the resolver above, rather than caching it at startup.
     location /api/ {
-        proxy_pass http://deuro-monitoring:3000/;
+        set $monitoring_upstream "deuro-monitoring";
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://$monitoring_upstream:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -15,7 +27,8 @@ server {
 
     # Swagger docs reverse proxy
     location /swagger {
-        proxy_pass http://deuro-monitoring:3000/swagger;
+        set $monitoring_upstream "deuro-monitoring";
+        proxy_pass http://$monitoring_upstream:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Symptom

After PR #42 was merged and deployed to dev, every \`https://dev.monitoring.deuro.com/api/*\` returned **HTTP 502** for ~10 minutes until nginx was manually restarted. Frontend (HTML) was reachable; only the API proxy was broken.

## Root cause

\`docker compose up\` recreated \`deuro-monitoring\` and \`postgres\` containers (compose schema changed on this PR), giving \`deuro-monitoring\` a new internal IP. The \`deuro-monitoring-web\` (nginx) container was NOT recreated — and nginx had resolved \`deuro-monitoring\` at startup and cached the old IP forever.

From the live nginx error log captured during the incident:
\`\`\`
upstream: "http://192.168.156.3:3000/positions"  ← cached, container gone
\`\`\`
while
\`\`\`
$ docker exec deuro-deuro-monitoring-web-1 getent hosts deuro-monitoring
192.168.156.7  deuro-monitoring   ← current IP
\`\`\`

This will happen on every future deploy that recreates the backend container, including production.

## Fix

Three changes to \`frontend/nginx.conf\`:

1. **\`resolver 127.0.0.11 ipv6=off valid=10s\`** — Docker's embedded DNS, 10-second cache. Stale IPs are corrected within 10 s automatically.
2. **\`proxy_pass\` with variable** (\`http://$monitoring_upstream:3000\`) — variables force nginx to re-resolve at request time via the resolver, instead of caching the static name at boot.
3. **Explicit \`rewrite ^/api/(.*)$ /$1 break\`** — once \`proxy_pass\` uses a variable, nginx no longer auto-strips the location prefix from the upstream URI; do it explicitly.

## Verification

- \`nginx -t\` passes against the new config (verified with \`docker run --rm -v $cfg:/etc/nginx/conf.d/default.conf nginx:alpine nginx -t\`).
- After this lands, recreate the \`deuro-monitoring\` container on dev and observe \`/api/positions\` continues to return 200 without manual intervention.

## Test plan

- [ ] Deploy lands on dev (CI auto-deploy)
- [ ] Once live: \`docker compose up -d --force-recreate deuro-monitoring\` on dev, watch \`curl https://dev.monitoring.deuro.com/api/positions\` recover within ≤10 s
- [ ] Promote to main only after dev is stable through one such recreate

## Out of scope

This does not change anything about the alert logic shipped in #42 — it's a pure proxy-config fix in the frontend image.