### PR TITLE
Tag telegram alerts with stack environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,7 @@ PG_MAX_CLIENTS=10
 # TELEGRAM_CHAT_ID=123456789
 # TELEGRAM_ALERTS_ENABLED=false
 # ALERT_TIMEFRAME_HOURS=12
+
+# Stack tag prepended to telegram alert headers (e.g. [DEV], [PRD]).
+# Helps distinguish origin when one bot/chat is shared across stacks.
+# ENVIRONMENT=dev

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -68,4 +68,8 @@ export class AppConfigService {
 	get coingeckoApiKey(): string | undefined {
 		return this.monitoringConfig.coingeckoApiKey || undefined;
 	}
+
+	get environment(): string {
+		return this.monitoringConfig.environment || 'dev';
+	}
 }

--- a/src/config/monitoring.config.ts
+++ b/src/config/monitoring.config.ts
@@ -70,6 +70,10 @@ export class MonitoringConfig {
 	@IsOptional()
 	@IsString()
 	coingeckoApiKey?: string;
+
+	@IsOptional()
+	@IsString()
+	environment?: string;
 }
 
 export default registerAs('monitoring', () => {
@@ -92,6 +96,7 @@ export default registerAs('monitoring', () => {
 	config.telegramAlertsEnabled = (process.env.TELEGRAM_ALERTS_ENABLED || 'false').toLowerCase() === 'true';
 	config.alertTimeframeHours = parseInt(process.env.ALERT_TIMEFRAME_HOURS || '12');
 	config.coingeckoApiKey = process.env.COINGECKO_API_KEY || '';
+	config.environment = (process.env.ENVIRONMENT || 'dev').toLowerCase();
 
 	const errors = validateSync(plainToClass(MonitoringConfig, config));
 	if (errors.length > 0) throw new Error(`Config validation failed: ${errors}`);

--- a/src/monitoringV2/telegram.service.ts
+++ b/src/monitoringV2/telegram.service.ts
@@ -122,10 +122,15 @@ export class TelegramService {
 
 	private constructMessage(event: Event, severity: string, time: string): string {
 		const severityIndicator = { HIGH: '🚨', MEDIUM: '', LOW: '' }[severity] || '';
+		const envTag = this.envTag();
 		const argsText = this.formatArgs(event.args);
 
+		const headerParts = [severityIndicator, envTag, `*${event.topic.replace(/([A-Z])/g, ' $1').trim()}*`].filter(
+			(part) => part.length > 0
+		);
+
 		const lines = [
-			`${severityIndicator} *${event.topic.replace(/([A-Z])/g, ' $1').trim()}*`,
+			headerParts.join(' '),
 			'',
 			severity ? `Severity: *${severity}*` : null,
 			`Time: ${time}`,
@@ -136,6 +141,12 @@ export class TelegramService {
 		].filter((line) => line !== null);
 
 		return lines.join('\n');
+	}
+
+	// Backslash-escaped square brackets so Telegram's Markdown parser renders them literally
+	// instead of interpreting `[…]` as the start of a link.
+	private envTag(): string {
+		return `\\[${this.config.environment.toUpperCase()}\\]`;
 	}
 
 	/**
@@ -152,7 +163,7 @@ export class TelegramService {
 		if (!this.enabled) return false;
 
 		try {
-			const formattedMessage = `🚨 *CRITICAL ALERT*\n\n${message}\n\n_Timestamp: ${new Date().toISOString()}_`;
+			const formattedMessage = `🚨 ${this.envTag()} *CRITICAL ALERT*\n\n${message}\n\n_Timestamp: ${new Date().toISOString()}_`;
 			await this.sendMessage(formattedMessage);
 			this.logger.log('Critical alert sent via Telegram');
 			return true;


### PR DESCRIPTION
## Summary

Today's incident review surfaced that the `monitoring` container on the production stack and the dev stack share a single telegram bot and chat, so the operator who receives the alerts cannot tell PRD events apart from DEV events. This PR closes that gap on the application side.

## Changes

- New optional `ENVIRONMENT` env var, parsed lower-case, default `dev`.
- `constructMessage` (per-event alerts) and `sendCriticalAlert` (heartbeat/error path) now prepend a bracketed env label to the header, e.g. `🚨 [PRD] *Position Opened*`.
- Square brackets are backslash-escaped so Telegram's Markdown parser renders them literally instead of treating `[…]` as the start of a link.
- Position-lifecycle watchers (mini-lifetime, expiring-soon, expired, phase-2) call into `sendCriticalAlert` and pick the tag up transparently — no per-watcher edits needed.
- `.env.example` documents the new variable.

## Out of scope (intentionally not in this PR)

- The longer-term fix is a dedicated PRD bot + operations group with multiple recipients. The bracket tag is the minimal change that makes the existing single-recipient setup readable in the meantime.
- The `[AppConfigService]: Configuration service initialized: {…}` log dumps every secret (bot token, RPC key, DB password) into Loki. That is a separate, higher-priority security PR.

## Test plan

- [ ] `npm run build` (passes locally)
- [ ] Manually verify a sample alert renders as `🚨 [PRD] *Position Opened*` in Telegram with `ENVIRONMENT=prd` set
- [ ] Verify no `parse_mode` errors from Telegram on the new header (escaped brackets)
- [ ] Roll out to dev with `ENVIRONMENT=dev`, then prod with `ENVIRONMENT=prd`