### PR TITLE
Add dedicated bridges monitoring

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { SystemOverview } from './components/SystemOverview';
 import { PositionsTable } from './components/PositionsTable';
 import { CollateralTable } from './components/CollateralTable';
 import { ChallengesTable } from './components/ChallengesTable';
+import { BridgesTable } from './components/BridgesTable';
 import { MintersTable } from './components/MintersTable';
 import { HealthStatus } from './components/HealthStatus';
 
@@ -13,10 +14,11 @@ function App() {
 		<div className="min-h-screen bg-neutral-950 text-gray-100">
 			<div className="max-w-7xl mx-auto p-4 space-y-6 text-sm mb-8">
 				<HealthStatus {...health} />
-				<SystemOverview {...deuro} />
+				<SystemOverview {...deuro} minters={minters} />
 				<PositionsTable data={positions} />
 				<CollateralTable {...collateral} />
-				<ChallengesTable data={challenges}/>
+				<ChallengesTable data={challenges} />
+				<BridgesTable data={minters} />
 				<MintersTable data={minters} />
 			</div>
 		</div>

--- a/frontend/src/components/BridgesTable.tsx
+++ b/frontend/src/components/BridgesTable.tsx
@@ -1,0 +1,91 @@
+import { MinterStatus, MinterType, type MinterResponse } from '../../../shared/types';
+import { Alignment, Table } from './Table';
+import type { Column, MultiLineCell } from './Table';
+import { formatNumber, formatCountdown, formatDateTime, formatPercent, getStatusColor } from '../lib/formatters';
+import { AddressLink } from './AddressLink';
+import { colors } from '../lib/theme';
+import type { DataState } from '../lib/api.hook';
+
+interface BridgesTableProps {
+	data?: DataState<MinterResponse[]>;
+}
+
+export function BridgesTable({ data }: BridgesTableProps) {
+	if (!data) return null;
+
+	const bridges: DataState<MinterResponse[]> = {
+		data: data.data?.filter((m) => m.type === MinterType.BRIDGE),
+		error: data.error,
+	};
+
+	const columns: Column<MinterResponse>[] = [
+		{
+			header: { primary: 'BRIDGE', secondary: 'STATUS' },
+			format: (bridge): MultiLineCell => ({
+				primary: (
+					<AddressLink
+						address={bridge.address}
+						className="font-mono"
+						bridgeTokenSymbol={bridge.bridgeTokenSymbol}
+					/>
+				),
+				secondary: bridge.status,
+				secondaryClass: getStatusColor(bridge.status),
+			}),
+		},
+		{
+			header: { primary: 'MINTED', secondary: 'LIMIT' },
+			align: Alignment.RIGHT,
+			format: (bridge): MultiLineCell => ({
+				primary: formatNumber(bridge.bridgeMinted || 0),
+				secondary: formatNumber(bridge.bridgeLimit || 0),
+			}),
+		},
+		{
+			header: { primary: 'UTIL. %', secondary: 'AVAILABLE' },
+			align: Alignment.RIGHT,
+			format: (bridge): MultiLineCell => {
+				const minted = bridge.bridgeMinted ? Number(bridge.bridgeMinted) : 0;
+				const limit = bridge.bridgeLimit ? Number(bridge.bridgeLimit) : 0;
+				const utilization = limit > 0 ? (minted * 100) / limit : undefined;
+				const available = limit > 0 ? formatNumber(limit - minted) : '-';
+				return {
+					primary: utilization !== undefined ? formatPercent(utilization) : '-',
+					secondary: available,
+					primaryClass: utilization !== undefined ? getUtilizationColor(utilization) : undefined,
+				};
+			},
+		},
+		{
+			header: { primary: 'EXPIRY', secondary: 'COUNTDOWN' },
+			align: Alignment.RIGHT,
+			format: (bridge): MultiLineCell => ({
+				primary: bridge.bridgeHorizon ? formatDateTime(Number(bridge.bridgeHorizon)) : '-',
+				secondary: bridge.bridgeHorizon ? formatCountdown(bridge.bridgeHorizon) : '-',
+			}),
+		},
+	];
+
+	return (
+		<Table
+			title="BRIDGES"
+			data={bridges.data}
+			error={bridges.error}
+			columns={columns}
+			getRowKey={(bridge) => bridge.address}
+			hidden={(bridge) => bridge.status === MinterStatus.DENIED || bridge.status === MinterStatus.EXPIRED}
+			sort={(a, b) => {
+				const mintedA = a.bridgeMinted ? Number(a.bridgeMinted) : 0;
+				const mintedB = b.bridgeMinted ? Number(b.bridgeMinted) : 0;
+				return mintedB - mintedA;
+			}}
+			emptyMessage="No bridges found"
+		/>
+	);
+}
+
+function getUtilizationColor(utilization: number): string {
+	if (utilization > 90) return colors.critical;
+	if (utilization > 70) return colors.highlight;
+	return colors.success;
+}

--- a/frontend/src/components/BridgesTable.tsx
+++ b/frontend/src/components/BridgesTable.tsx
@@ -20,7 +20,7 @@ export function BridgesTable({ data }: BridgesTableProps) {
 
 	const columns: Column<MinterResponse>[] = [
 		{
-			header: { primary: 'BRIDGE', secondary: 'STATUS' },
+			header: { primary: 'BRIDGE', secondary: 'TOKEN' },
 			format: (bridge): MultiLineCell => ({
 				primary: (
 					<AddressLink
@@ -29,9 +29,23 @@ export function BridgesTable({ data }: BridgesTableProps) {
 						bridgeTokenSymbol={bridge.bridgeTokenSymbol}
 					/>
 				),
-				secondary: bridge.status,
-				secondaryClass: getStatusColor(bridge.status),
+				secondary: bridge.bridgeToken ? (
+					<AddressLink address={bridge.bridgeToken} showKnownLabel={false} className="font-mono" />
+				) : '-',
 			}),
+		},
+		{
+			header: { primary: 'START', secondary: 'STATUS' },
+			format: (bridge): MultiLineCell => {
+				const startTimestamp = Number(bridge.applicationTimestamp) + Number(bridge.applicationPeriod) * 1000;
+				const hasStarted = startTimestamp <= Date.now();
+				return {
+					primary: hasStarted ? formatDateTime(startTimestamp) : formatCountdown(startTimestamp),
+					secondary: bridge.status,
+					primaryClass: hasStarted ? undefined : colors.critical,
+					secondaryClass: getStatusColor(bridge.status),
+				};
+			},
 		},
 		{
 			header: { primary: 'MINTED', secondary: 'LIMIT' },

--- a/frontend/src/components/MintersTable.tsx
+++ b/frontend/src/components/MintersTable.tsx
@@ -1,7 +1,7 @@
 import { MinterStatus, MinterType, type MinterResponse } from '../../../shared/types';
 import { Alignment, Table } from './Table';
 import type { Column, MultiLineCell } from './Table';
-import { formatNumber, formatCountdown, formatDateTime, formatPercent, getStatusColor } from '../lib/formatters';
+import { formatNumber, formatCountdown, formatDateTime, getStatusColor } from '../lib/formatters';
 import { AddressLink } from './AddressLink';
 import { colors } from '../lib/theme';
 import type { DataState } from '../lib/api.hook';
@@ -13,16 +13,17 @@ interface MinterTableProps {
 export function MintersTable({ data }: MinterTableProps) {
 	if (!data) return null;
 
+	const genericMinters: DataState<MinterResponse[]> = {
+		data: data.data?.filter((m) => m.type !== MinterType.BRIDGE),
+		error: data.error,
+	};
+
 	const columns: Column<MinterResponse>[] = [
 		{
-			header: { primary: 'MINTER', secondary: 'MESSAGE' },
+			header: { primary: 'MINTER', secondary: 'STATUS' },
 			format: (minter): MultiLineCell => ({
 				primary: (
-					<AddressLink
-						address={minter.address}
-						className="font-mono"
-						bridgeTokenSymbol={minter.type === MinterType.BRIDGE ? minter.bridgeTokenSymbol : undefined}
-					/>
+					<AddressLink address={minter.address} className="font-mono" />
 				),
 				secondary: minter.status,
 				secondaryClass: getStatusColor(minter.status),
@@ -41,50 +42,19 @@ export function MintersTable({ data }: MinterTableProps) {
 			},
 		},
 		{
-			header: { primary: 'MINTED', secondary: 'LIMIT' },
+			header: { primary: 'FEE' },
 			align: Alignment.RIGHT,
-			format: (minter): MultiLineCell => {
-				const isBridge = minter.type === MinterType.BRIDGE;
-				return {
-					primary: isBridge ? formatNumber(minter.bridgeMinted || 0) : '-',
-					secondary: isBridge ? formatNumber(minter.bridgeLimit || 0) : '-',
-				};
-			},
-		},
-		{
-			header: { primary: 'UTIL. %', secondary: 'AVAILABLE' },
-			align: Alignment.RIGHT,
-			format: (minter) => {
-				const isBridge = minter.type === MinterType.BRIDGE;
-				const minted = isBridge && minter.bridgeMinted ? Number(minter.bridgeMinted) : 0;
-				const limit = isBridge && minter.bridgeLimit ? Number(minter.bridgeLimit) : 0;
-				const utilization = limit > 0 ? (minted * 100) / limit : undefined;
-				const availableForMint = limit > 0 ? formatNumber(limit - minted) : '-';
-				return {
-					primary: utilization !== undefined ? formatPercent(utilization) : '-',
-					secondary: availableForMint,
-					primaryClass: utilization !== undefined ? getUtilizationColor(utilization) : undefined,
-				};
-			},
-		},
-		{
-			header: { primary: 'EXPIRY', secondary: 'COUNTDOWN' },
-			align: Alignment.RIGHT,
-			format: (minter): MultiLineCell => {
-				const isBridge = minter.type === MinterType.BRIDGE;
-				return {
-					primary: isBridge && minter.bridgeHorizon ? formatDateTime(Number(minter.bridgeHorizon)) : '-',
-					secondary: isBridge && minter.bridgeHorizon ? formatCountdown(minter.bridgeHorizon) : '-',
-				};
-			},
+			format: (minter): MultiLineCell => ({
+				primary: formatNumber(minter.applicationFee),
+			}),
 		},
 	];
 
 	return (
 		<Table
 			title="MINTERS"
-			data={data?.data}
-			error={data?.error}
+			data={genericMinters.data}
+			error={genericMinters.error}
 			columns={columns}
 			getRowKey={(minter) => minter.address}
 			hidden={(minter) => minter.status === MinterStatus.DENIED || minter.status === MinterStatus.EXPIRED}
@@ -92,10 +62,4 @@ export function MintersTable({ data }: MinterTableProps) {
 			emptyMessage="No minters found"
 		/>
 	);
-}
-
-function getUtilizationColor(utilization: number): string {
-	if (utilization > 90) return colors.critical;
-	if (utilization > 70) return colors.highlight;
-	return colors.success;
 }

--- a/frontend/src/components/SystemOverview.tsx
+++ b/frontend/src/components/SystemOverview.tsx
@@ -1,14 +1,25 @@
-import type { DeuroState } from '../../../shared/types';
+import type { DeuroState, MinterResponse } from '../../../shared/types';
+import { MinterStatus, MinterType } from '../../../shared/types';
 import { colors, spacing } from '../lib/theme';
 import { formatNumber, formatPercent } from '../lib/formatters';
 import type { DataState } from '../lib/api.hook';
 
-export function SystemOverview({ data, error }: DataState<DeuroState>) {
+interface SystemOverviewProps extends DataState<DeuroState> {
+	minters?: DataState<MinterResponse[]>;
+}
+
+export function SystemOverview({ data, error, minters }: SystemOverviewProps) {
 	if (error) return <div className={colors.critical}>{error}</div>;
 	if (!data) return null;
 
 	const deuroProfit = parseFloat(data.deuroProfit);
 	const netProfit = deuroProfit - parseFloat(data.deuroLoss);
+
+	const bridges = minters?.data?.filter((m) => m.type === MinterType.BRIDGE && m.status !== MinterStatus.DENIED) || [];
+	const activeBridges = bridges.filter((b) => b.status === MinterStatus.APPROVED);
+	const bridgeTotalMinted = bridges.reduce((sum, b) => sum + (b.bridgeMinted ? Number(b.bridgeMinted) : 0), 0);
+	const bridgeTotalLimit = bridges.reduce((sum, b) => sum + (b.bridgeLimit ? Number(b.bridgeLimit) : 0), 0);
+	const bridgeUtilization = bridgeTotalLimit > 0 ? (bridgeTotalMinted * 100) / bridgeTotalLimit : 0;
 
 	return (
 		<div className={`${colors.background} ${colors.table.border} border rounded-xl p-4`}>
@@ -65,6 +76,15 @@ export function SystemOverview({ data, error }: DataState<DeuroState>) {
 					</Section>
 				)}
 
+				{bridges.length > 0 && (
+					<Section title="BRIDGES">
+						<Metric label="Active" value={`${activeBridges.length} / ${bridges.length}`} />
+						<Metric label="Minted" value={formatNumber(bridgeTotalMinted, 0, 2)} valueClass={colors.text.primary} />
+						<Metric label="Capacity" value={formatNumber(bridgeTotalLimit, 0, 2)} />
+						<Metric label="Utilization" value={formatPercent(bridgeUtilization)} valueClass={getBridgeUtilizationColor(bridgeUtilization)} />
+					</Section>
+				)}
+
 				{(data.usdToEurRate || data.usdToChfRate) && (
 					<Section title="CURRENCY RATES">
 						{data.usdToEurRate && <Metric label="USD/EUR" value={formatNumber(1 / data.usdToEurRate, 0, 4)} />}
@@ -74,6 +94,12 @@ export function SystemOverview({ data, error }: DataState<DeuroState>) {
 			</div>
 		</div>
 	);
+}
+
+function getBridgeUtilizationColor(utilization: number): string {
+	if (utilization > 90) return colors.critical;
+	if (utilization > 70) return colors.highlight;
+	return colors.success;
 }
 
 function Metric({ label, value, valueClass = colors.text.secondary }: { label: string; value: string | number; valueClass?: string }) {


### PR DESCRIPTION
## Summary
- New `BridgesTable` component showing all stablecoin bridges with minted/limit, utilization %, available capacity, and expiry countdown
- New "BRIDGES" section in SystemOverview with aggregate metrics (active count, total minted, total capacity, overall utilization)
- MintersTable now shows only generic minters (bridges separated into own table)

## Test plan
- [ ] Verify BridgesTable displays all active bridges sorted by minted amount
- [ ] Verify expired/denied bridges are hidden by default but showable
- [ ] Verify SystemOverview BRIDGES section shows correct aggregates
- [ ] Verify MintersTable no longer shows bridge entries
- [ ] Verify utilization color coding (green <70%, yellow 70-90%, red >90%)