### PR TITLE
Redact secrets in bootstrap config log

### DIFF
--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -2,6 +2,14 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MonitoringConfig } from './monitoring.config';
 
+const SENSITIVE_KEYS = new Set<keyof MonitoringConfig>(['rpcUrl', 'databaseUrl', 'telegramBotToken', 'coingeckoApiKey']);
+
+function redactConfig(config: MonitoringConfig): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(config).map(([key, value]) => [key, SENSITIVE_KEYS.has(key as keyof MonitoringConfig) && value ? '***' : value])
+	);
+}
+
 @Injectable()
 export class AppConfigService {
 	private readonly logger = new Logger(AppConfigService.name);
@@ -10,7 +18,7 @@ export class AppConfigService {
 	constructor(private readonly configService: ConfigService) {
 		this.monitoringConfig = this.configService.get<MonitoringConfig>('monitoring');
 		if (!this.monitoringConfig) throw new Error('Monitoring configuration not found');
-		this.logger.log(`Configuration service initialized: ${JSON.stringify(this.monitoringConfig)}`);
+		this.logger.log(`Configuration service initialized: ${JSON.stringify(redactConfig(this.monitoringConfig))}`);
 	}
 
 	get rpcUrl(): string {

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -2,12 +2,23 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MonitoringConfig } from './monitoring.config';
 
-const SENSITIVE_KEYS = new Set<keyof MonitoringConfig>(['rpcUrl', 'databaseUrl', 'telegramBotToken', 'coingeckoApiKey']);
+const SENSITIVE_KEYS = new Set<string>(['rpcUrl', 'databaseUrl', 'telegramBotToken', 'coingeckoApiKey']);
 
-function redactConfig(config: MonitoringConfig): Record<string, unknown> {
-	return Object.fromEntries(
-		Object.entries(config).map(([key, value]) => [key, SENSITIVE_KEYS.has(key as keyof MonitoringConfig) && value ? '***' : value])
-	);
+function redactConfig<T>(config: T): T {
+	return walkRedact(config, '') as T;
+}
+
+function walkRedact(value: unknown, path: string): unknown {
+	if (value && typeof value === 'object' && !Array.isArray(value)) {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>).map(([key, val]) => {
+				const childPath = path ? `${path}.${key}` : key;
+				if (SENSITIVE_KEYS.has(childPath) && val) return [key, '***'];
+				return [key, walkRedact(val, childPath)];
+			})
+		);
+	}
+	return value;
 }
 
 @Injectable()


### PR DESCRIPTION
## Summary

- Avoid serializing sensitive config fields in the bootstrap log produced by `AppConfigService`.
- Adds a small `redactConfig()` helper driven by an explicit `SENSITIVE_KEYS` set; matching values are replaced with `***` before `JSON.stringify`.

## Test plan

- [ ] `npm run build` clean
- [ ] Container-Log nach Start zeigt `***` für die als sensitiv markierten Felder