### PR TITLE
Enable PositionDenied alerts at medium severity

### DIFF
--- a/src/monitoringV2/events.config.ts
+++ b/src/monitoringV2/events.config.ts
@@ -13,7 +13,7 @@ export const EVENT_CONFIG: Record<string, EventConfig> = {
 	// Position events
 	PositionOpened: { severity: EventSeverity.HIGH, enabled: true },
 	MintingUpdate: { severity: EventSeverity.HIGH, enabled: true },
-	PositionDenied: { severity: EventSeverity.LOW, enabled: false },
+	PositionDenied: { severity: EventSeverity.MEDIUM, enabled: true },
 
 	// Challenge events
 	ChallengeStarted: { severity: EventSeverity.MEDIUM, enabled: true },


### PR DESCRIPTION
## Summary

- Switches `PositionDenied` from `{severity: LOW, enabled: false}` to `{severity: MEDIUM, enabled: true}` in `events.config.ts`.
- A DEPS-holder denying a position is forensically and operationally relevant; surfacing it as an alert lets operators correlate with suspicious openings.

## Test plan

- [ ] `npm run build` clean
- [ ] After deploy: trigger or wait for a `Position.deny` event and verify a MEDIUM-severity Telegram alert is delivered