### PR TITLE
Add optional CHAIN tag and drop fallbacks on telegram alert tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ PG_MAX_CLIENTS=10
 # TELEGRAM_ALERTS_ENABLED=false
 # ALERT_TIMEFRAME_HOURS=12
 
-# Stack tag prepended to telegram alert headers (e.g. [DEV], [PRD]).
-# Helps distinguish origin when one bot/chat is shared across stacks.
+# Tier tag prepended to telegram alert headers (e.g. [DEV], [PRD]).
+# Identifies the server tier; deploy convention is dfxprd -> prd, dfxdev -> dev.
 # ENVIRONMENT=dev
+
+# Optional chain name prepended to telegram alert headers after the tier tag
+# (e.g. [PRD] [MAINNET]). Identifies which chain a multi-chain monitoring stack
+# observes when the same chat receives alerts from several chains. Leave
+# unset on single-chain stacks. Free-form value, rendered upper-cased.
+# CHAIN=Mainnet

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -88,7 +88,11 @@ export class AppConfigService {
 		return this.monitoringConfig.coingeckoApiKey || undefined;
 	}
 
-	get environment(): string {
-		return this.monitoringConfig.environment || 'dev';
+	get environment(): string | undefined {
+		return this.monitoringConfig.environment;
+	}
+
+	get chain(): string | undefined {
+		return this.monitoringConfig.chain;
 	}
 }

--- a/src/config/monitoring.config.ts
+++ b/src/config/monitoring.config.ts
@@ -74,6 +74,10 @@ export class MonitoringConfig {
 	@IsOptional()
 	@IsString()
 	environment?: string;
+
+	@IsOptional()
+	@IsString()
+	chain?: string;
 }
 
 export default registerAs('monitoring', () => {
@@ -96,7 +100,8 @@ export default registerAs('monitoring', () => {
 	config.telegramAlertsEnabled = (process.env.TELEGRAM_ALERTS_ENABLED || 'false').toLowerCase() === 'true';
 	config.alertTimeframeHours = parseInt(process.env.ALERT_TIMEFRAME_HOURS || '12');
 	config.coingeckoApiKey = process.env.COINGECKO_API_KEY || '';
-	config.environment = (process.env.ENVIRONMENT || 'dev').toLowerCase();
+	config.environment = process.env.ENVIRONMENT?.toLowerCase();
+	config.chain = process.env.CHAIN;
 
 	const errors = validateSync(plainToClass(MonitoringConfig, config));
 	if (errors.length > 0) throw new Error(`Config validation failed: ${errors}`);

--- a/src/monitoringV2/telegram.service.ts
+++ b/src/monitoringV2/telegram.service.ts
@@ -144,9 +144,13 @@ export class TelegramService {
 	}
 
 	// Backslash-escaped square brackets so Telegram's Markdown parser renders them literally
-	// instead of interpreting `[…]` as the start of a link.
+	// instead of interpreting `[…]` as the start of a link. Combines tier tag (env) and
+	// optional chain — set CHAIN to render e.g. `[PRD] [MAINNET]`, leave unset to
+	// render only `[PRD]`. Either side is omitted if the corresponding env var is unset.
 	private envTag(): string {
-		return `\\[${this.config.environment.toUpperCase()}\\]`;
+		const env = this.config.environment ? `\\[${this.config.environment.toUpperCase()}\\]` : '';
+		const chain = this.config.chain ? `\\[${this.config.chain.toUpperCase()}\\]` : '';
+		return [env, chain].filter((part) => part.length > 0).join(' ');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Tier (DEV/PRD) and chain (mainnet/testnet/...) are orthogonal axes in the alert header.

- Adds an optional `CHAIN` env var, free-form value rendered upper-cased after the tier tag (e.g. `🚨 [PRD] [MAINNET] *Position Opened*`). Single-chain stacks omit it; multi-chain stacks set it to distinguish chains.
- Removes default-value fallbacks (`|| 'dev'`) on `ENVIRONMENT`. Both tags are now strictly optional: if an env var is unset, the corresponding bracket is omitted from the header.
- Mirrors the JuiceDollar/monitoring#21 change so both codebases share the same tagging mechanism.

### Header rendering examples

| Stack | ENVIRONMENT | CHAIN | Header |
|---|---|---|---|
| dEURO PRD | prd | Mainnet | `🚨 [PRD] [MAINNET] *Position Opened*` |
| dEURO DEV | dev | Mainnet | `🚨 [DEV] [MAINNET] *Position Opened*` |
| Single-chain, no CHAIN | prd | — | `🚨 [PRD] *Position Opened*` |
| Both unset | — | — | `🚨 *Position Opened*` |

## Test plan

- [ ] `npm run build` clean
- [ ] After deploy with `ENVIRONMENT=prd CHAIN=Mainnet`: alert header renders `🚨 [PRD] [MAINNET] *…*`
- [ ] Verify no `parse_mode` errors from Telegram on the new header (escaped brackets)