### PR TITLE
Detect equity-drain attempts via liq-price/spot/value/challengeability checks

### DIFF
--- a/src/monitoringV2/monitoring.service.ts
+++ b/src/monitoringV2/monitoring.service.ts
@@ -135,6 +135,7 @@ export class MonitoringService implements OnModuleInit {
 		await this.minterService.syncMinters(); // sync minter states
 		await this.deuroService.syncState(); // sync dEURO global state
 		await this.positionService.checkMiniLifetimeClones(this.telegramService); // suspicious short-lifetime clones
+		await this.positionService.checkSuspiciousLiqPrice(this.telegramService); // liq-price/spot/value/challengeability sanity
 		await this.positionService.checkExpiringSoon(this.telegramService); // 24h heads-up before expiration
 		await this.positionService.checkExpired(this.telegramService); // transition into expired status
 		await this.positionService.checkExpiredInPhase2(this.telegramService); // phase 2 of forced-sale decay

--- a/src/monitoringV2/position.service.ts
+++ b/src/monitoringV2/position.service.ts
@@ -6,12 +6,20 @@ import { ethers } from 'ethers';
 import { ProviderService } from './provider.service';
 import { PositionRepository } from './prisma/repositories/position.repository';
 import { EventsRepository } from './prisma/repositories/events.repository';
+import { TokenRepository } from './prisma/repositories/token.repository';
 import { TelegramService } from './telegram.service';
+import { PriceService } from './price.service';
 
 // Anything below is suspicious for a clone — the WFPS attacker used a 36-second clone.
 const MINI_LIFETIME_THRESHOLD_SECONDS = 86_400n; // 1 day
 const EXPIRING_SOON_WINDOW_SECONDS = 86_400n; // 24 h heads-up before expiration
 const TELEGRAM_THROTTLE_MS = 100; // stay under per-chat rate limit (~30 msg/s) when bursting
+
+// Liq-price sanity-check thresholds. Conservative on purpose — false positives are cheap
+// during the 3-day init period; missed alerts are not.
+const LIQ_PRICE_OVER_SPOT_RATIO = 2.0; // virtualPrice / coingeckoSpot above this is suspicious
+const MIN_POSITION_VALUE_DEURO = 500n * 10n ** 18n; // V3 hardcodes this floor; V2 does not
+const CHALLENGER_REWARD_PPM = 20_000; // 2% — matches MintingHub's hardcoded constant
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -24,7 +32,9 @@ export class PositionService {
 		private readonly config: AppConfigService,
 		private readonly positionRepo: PositionRepository,
 		private readonly eventsRepo: EventsRepository,
-		private readonly providerService: ProviderService
+		private readonly providerService: ProviderService,
+		private readonly tokenRepo: TokenRepository,
+		private readonly priceService: PriceService
 	) {}
 
 	async initialize(): Promise<void> {
@@ -304,6 +314,103 @@ export class PositionService {
 			if (delivered) {
 				await this.positionRepo.markPhase2Alerted(p.address, now);
 				this.logger.warn(`Phase-2 alert sent for ${p.address} (timePassed=${timePassed}s)`);
+			}
+			await sleep(TELEGRAM_THROTTLE_MS);
+		}
+	}
+
+	/**
+	 * Detect open positions whose parameters indicate a likely abuse attempt — set up
+	 * to drain the equity reserve via the forced-sale decay rather than to borrow legitimately.
+	 *
+	 * Three independent triggers (any one fires the alert):
+	 *  1. Liq-price ≥ LIQ_PRICE_OVER_SPOT_RATIO × coingecko spot. Catches the 2026-04-27
+	 *     pattern where liq-price was ~1000× the real ETH price.
+	 *  2. Position value (minimumCollateral × liq-price) below MIN_POSITION_VALUE_DEURO.
+	 *     V3 hardcodes a 500 dEURO floor in MintingHub; V2 does not, so a watcher closes
+	 *     the gap for V2 positions.
+	 *  3. riskPremiumPPM == 0 AND reservePPM ≤ CHALLENGER_REWARD_PPM. Such a position
+	 *     cannot be profitably challenged — the challenger reward exceeds the seizable
+	 *     reserve — so legitimate borrowers don't pick this combination.
+	 *
+	 * Per-position dedup via suspicious_liq_price_alerted_at.
+	 */
+	async checkSuspiciousLiqPrice(telegramService: TelegramService): Promise<void> {
+		const candidates = await this.positionRepo.findUnalertedSuspiciousLiqPrice();
+		if (candidates.length === 0) return;
+
+		const tokens = await this.tokenRepo.findAll();
+		const decimalsByToken = new Map<string, number>();
+		for (const t of tokens) {
+			if (t.decimals !== undefined && t.decimals !== null) {
+				decimalsByToken.set(t.address.toLowerCase(), Number(t.decimals));
+			}
+		}
+
+		const collateralAddrs = [...new Set(candidates.map((c) => c.collateral.toLowerCase()))];
+		const spotPrices = await this.priceService.getTokenPricesInEur(collateralAddrs);
+
+		const now = BigInt(Math.floor(Date.now() / 1000));
+		for (const c of candidates) {
+			const reasons: string[] = [];
+			const collateralAddr = c.collateral.toLowerCase();
+			const decimals = decimalsByToken.get(collateralAddr);
+			const virtualPrice = BigInt(c.virtualPrice);
+			const minimumCollateral = BigInt(c.minimumCollateral);
+
+			// Trigger 1: liq-price vs coingecko spot ratio (only when both decimals and spot known).
+			// virtualPrice is in (36 - collateralDecimals) decimals; format to dEURO per 1 collateral
+			// unit before comparing with the EUR spot.
+			const spotEurStr = spotPrices[collateralAddr];
+			if (decimals !== undefined && spotEurStr !== undefined) {
+				const virtualPriceFormatted = Number(ethers.formatUnits(virtualPrice, 36 - decimals));
+				const spotEur = Number(spotEurStr);
+				if (spotEur > 0 && virtualPriceFormatted / spotEur >= LIQ_PRICE_OVER_SPOT_RATIO) {
+					reasons.push(
+						`liq-price ${virtualPriceFormatted.toLocaleString('en-US', { maximumFractionDigits: 2 })} ` +
+							`dEURO/token is ${(virtualPriceFormatted / spotEur).toFixed(1)}× the coingecko spot ` +
+							`of ${spotEur.toLocaleString('en-US', { maximumFractionDigits: 4 })} EUR/token`
+					);
+				}
+			}
+
+			// Trigger 2: position face value below the 500-dEURO floor.
+			// minimumCollateral × virtualPrice / 1e18 collapses the (collateralDecimals + 36 - collateralDecimals)
+			// product back down to 18-decimal dEURO regardless of token decimals.
+			const positionValue = (minimumCollateral * virtualPrice) / 10n ** 18n;
+			if (positionValue < MIN_POSITION_VALUE_DEURO) {
+				reasons.push(
+					`min-collateral × liq-price = ${formatDeuro(positionValue.toString())} dEURO ` +
+						`(below the V3-enforced floor of 500 dEURO)`
+				);
+			}
+
+			// Trigger 3: zero risk premium plus reserve not even covering the challenger reward —
+			// position is structured so it cannot be profitably challenged.
+			if (c.riskPremiumPpm === 0 && c.reserveContribution <= CHALLENGER_REWARD_PPM) {
+				reasons.push(
+					`riskPremiumPPM=0 and reservePPM=${c.reserveContribution} ≤ challenger reward ` +
+						`(${CHALLENGER_REWARD_PPM}); position cannot be profitably challenged`
+				);
+			}
+
+			if (reasons.length === 0) continue;
+
+			const message =
+				`Suspicious position parameters\n\n` +
+				`Position: \`${c.address}\`\n` +
+				`Owner: \`${c.owner}\`\n` +
+				`Collateral: \`${c.collateral}\`\n\n` +
+				`Triggers:\n${reasons.map((r) => `• ${r}`).join('\n')}\n\n` +
+				`Set-up matches the pattern of equity-drain attempts (liq-price miscalibrated ` +
+				`relative to spot, micro-collateral, or unchallengeable parameters). Review the ` +
+				`position before its 3-day init period elapses.\n\n` +
+				`[Etherscan](https://etherscan.io/address/${c.address})`;
+
+			const delivered = await telegramService.sendCriticalAlert(message);
+			if (delivered) {
+				await this.positionRepo.markSuspiciousLiqPriceAlerted(c.address, now);
+				this.logger.warn(`Suspicious-liq-price alert sent for ${c.address} (${reasons.length} trigger(s))`);
 			}
 			await sleep(TELEGRAM_THROTTLE_MS);
 		}

--- a/src/monitoringV2/prisma/migrations/0004_position_suspicious_liq_price_alert/migration.sql
+++ b/src/monitoringV2/prisma/migrations/0004_position_suspicious_liq_price_alert/migration.sql
@@ -1,0 +1,4 @@
+-- Track when the suspicious-liq-price watcher last fired for a position so we
+-- don't re-alert every cycle.
+ALTER TABLE "position_states"
+  ADD COLUMN "suspicious_liq_price_alerted_at" BIGINT;

--- a/src/monitoringV2/prisma/repositories/position.repository.ts
+++ b/src/monitoringV2/prisma/repositories/position.repository.ts
@@ -362,4 +362,49 @@ export class PositionRepository {
 			data: { expiredAlertedAt: timestamp },
 		});
 	}
+
+	async findUnalertedSuspiciousLiqPrice(): Promise<
+		Array<{
+			address: string;
+			owner: string;
+			collateral: string;
+			minimumCollateral: string;
+			riskPremiumPpm: number;
+			reserveContribution: number;
+			virtualPrice: string;
+		}>
+	> {
+		const rows = await this.prisma.positionState.findMany({
+			where: {
+				suspiciousLiqPriceAlertedAt: null,
+				isClosed: false,
+				isDenied: false,
+			},
+			select: {
+				address: true,
+				owner: true,
+				collateral: true,
+				minimumCollateral: true,
+				riskPremiumPpm: true,
+				reserveContribution: true,
+				virtualPrice: true,
+			},
+		});
+		return rows.map((r) => ({
+			address: r.address,
+			owner: r.owner,
+			collateral: r.collateral,
+			minimumCollateral: r.minimumCollateral.toFixed(0),
+			riskPremiumPpm: r.riskPremiumPpm,
+			reserveContribution: r.reserveContribution,
+			virtualPrice: r.virtualPrice.toFixed(0),
+		}));
+	}
+
+	async markSuspiciousLiqPriceAlerted(address: string, timestamp: bigint): Promise<void> {
+		await this.prisma.positionState.update({
+			where: { address: address.toLowerCase() },
+			data: { suspiciousLiqPriceAlertedAt: timestamp },
+		});
+	}
 }

--- a/src/monitoringV2/prisma/schema.prisma
+++ b/src/monitoringV2/prisma/schema.prisma
@@ -96,10 +96,11 @@ model PositionState {
   isDenied              Boolean @default(false) @map("is_denied")
 
   // Alert dedup: timestamps of last sent alerts to avoid spam across cycles
-  miniLifetimeAlertedAt  BigInt? @map("mini_lifetime_alerted_at") // Unix seconds
-  expiringSoonAlertedAt  BigInt? @map("expiring_soon_alerted_at") // Unix seconds
-  expiredAlertedAt       BigInt? @map("expired_alerted_at") // Unix seconds
-  phase2AlertedAt        BigInt? @map("phase2_alerted_at") // Unix seconds
+  miniLifetimeAlertedAt       BigInt? @map("mini_lifetime_alerted_at") // Unix seconds
+  expiringSoonAlertedAt       BigInt? @map("expiring_soon_alerted_at") // Unix seconds
+  expiredAlertedAt            BigInt? @map("expired_alerted_at") // Unix seconds
+  phase2AlertedAt             BigInt? @map("phase2_alerted_at") // Unix seconds
+  suspiciousLiqPriceAlertedAt BigInt? @map("suspicious_liq_price_alerted_at") // Unix seconds
 
   // Metadata
   timestamp DateTime @db.Timestamptz


### PR DESCRIPTION
## Summary

Three-trigger watcher (`checkSuspiciousLiqPrice`) that fires a HIGH-severity alert when an open position shows parameters typical of an equity-drain attempt rather than legitimate borrowing. Plugged into the existing scheduler alongside the other position watchers.

### Triggers (any one fires)

1. **Liq-price ≥ 2× coingecko spot** for the collateral. Catches the 2026-04-27 pattern where the liq-price was ~1000× the real ETH price; ratio ≥ 2 keeps false positives bounded while flagging genuine miscalibrations.
2. **Position face value < 500 dEURO** (`minimumCollateral × liq-price / 1e18`). V3 hardcodes this floor; V2 does not, so the watcher closes the gap for V2 positions.
3. **`riskPremiumPPM == 0` AND `reservePPM ≤ 20_000`** (the challenger reward). Such a position cannot be profitably challenged — legitimate borrowers don't pick this combination.

### Implementation

- New `suspicious_liq_price_alerted_at` column on `position_states` (migration `0004`) for per-position dedup, analogous to the existing `mini_lifetime_alerted_at` / `phase2_alerted_at` columns.
- New repo methods `findUnalertedSuspiciousLiqPrice` / `markSuspiciousLiqPriceAlerted`.
- Watcher loops `non-closed && non-denied && not-yet-alerted` positions, fetches collateral spot prices once per cycle via `PriceService.getTokenPricesInEur`, looks up token decimals from the existing tokens table, evaluates the three triggers, and uses `sendCriticalAlert` for delivery confirmation (no DB write on failed delivery → next cycle retries).
- Per-position throttle preserves the 100ms gap shared with the other watchers.

## Test plan

- [ ] `npm run build` clean
- [ ] On a fresh DB: confirm migration `0004` applies cleanly
- [ ] Create a synthetic V2 position with liq-price 1000× spot → alert fires
- [ ] Confirm second cycle does not re-fire (`suspicious_liq_price_alerted_at` set)
- [ ] Verify alert renders correctly in Telegram with all three triggers listed when applicable