### PR TITLE
Isolate watcher failures from siblings via runWatcher wrapper

### DIFF
--- a/src/monitoringV2/monitoring.service.ts
+++ b/src/monitoringV2/monitoring.service.ts
@@ -134,11 +134,14 @@ export class MonitoringService implements OnModuleInit {
 		await this.collateralService.syncCollaterals(); // sync collateral states
 		await this.minterService.syncMinters(); // sync minter states
 		await this.deuroService.syncState(); // sync dEURO global state
-		await this.positionService.checkMiniLifetimeClones(this.telegramService); // suspicious short-lifetime clones
-		await this.positionService.checkSuspiciousLiqPrice(this.telegramService); // liq-price/spot/value/challengeability sanity
-		await this.positionService.checkExpiringSoon(this.telegramService); // 24h heads-up before expiration
-		await this.positionService.checkExpired(this.telegramService); // transition into expired status
-		await this.positionService.checkExpiredInPhase2(this.telegramService); // phase 2 of forced-sale decay
+		// Watchers wrapped individually so a bug in one cannot mask the alerts of the others.
+		// A throwing watcher is logged and the cycle continues; the outer try/catch is reserved
+		// for genuine sync-pipeline failures that need the consecutive-failures escalation.
+		await this.runWatcher('checkMiniLifetimeClones', () => this.positionService.checkMiniLifetimeClones(this.telegramService));
+		await this.runWatcher('checkSuspiciousLiqPrice', () => this.positionService.checkSuspiciousLiqPrice(this.telegramService));
+		await this.runWatcher('checkExpiringSoon', () => this.positionService.checkExpiringSoon(this.telegramService));
+		await this.runWatcher('checkExpired', () => this.positionService.checkExpired(this.telegramService));
+		await this.runWatcher('checkExpiredInPhase2', () => this.positionService.checkExpiredInPhase2(this.telegramService));
 		await this.telegramService.sendPendingAlerts(); // send pending telegram alerts
 
 		// Mark full cycle as completed
@@ -158,5 +161,21 @@ export class MonitoringService implements OnModuleInit {
 			this.consecutiveFailures > 0 &&
 			(this.consecutiveFailures === 3 || this.consecutiveFailures === 12 || this.consecutiveFailures % 72 === 0) // ~ 6 hour heartbeat
 		);
+	}
+
+	/**
+	 * Run a watcher with isolated error handling: exceptions are logged with context
+	 * and swallowed so the sibling watchers in the same cycle still get to run. The
+	 * outer scheduler try/catch is reserved for sync-pipeline failures that warrant
+	 * the consecutive-failures escalation; one watcher silently failing should not
+	 * trigger the same path or block the others.
+	 */
+	private async runWatcher(name: string, fn: () => Promise<void>): Promise<void> {
+		try {
+			await fn();
+		} catch (error) {
+			const errorMsg = typeof error?.message === 'string' && error.message ? error.message : String(error);
+			this.logger.error(`Watcher ${name} failed: ${errorMsg}`, error?.stack || error);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

If one of the five position watchers throws, the outer scheduler `try/catch` catches it but skips every later watcher in the same cycle, increments `consecutiveFailures`, and (after threshold) fires a `Monitoring system stuck` alert — even though the failure is isolated to one watcher and the others would have run fine.

This PR wraps each watcher call in a `runWatcher` helper:

- Exception is caught, logged with the watcher name + stack
- Sibling watchers in the same cycle still get to run
- The outer try/catch is reserved for genuine sync-pipeline failures (`getBlockRangeToProcess`, `processBlocks`) that should escalate via `consecutiveFailures`

### Failure model before / after

| Scenario | Before | After |
|---|---|---|
| `checkSuspiciousLiqPrice` throws | `checkExpiringSoon`, `checkExpired`, `checkExpiredInPhase2` all skipped; `consecutiveFailures++`; eventual `system stuck` alert | only that one logged; the other 4 still run; cycle marks completed normally |
| Sync pipeline (`syncPositions` etc.) throws | unchanged — outer catch + `consecutiveFailures` | unchanged |

Defense-in-depth follow-up to d-EURO/monitoring#56. Mirrors the equivalent JuiceDollar/monitoring patch.

## Test plan

- [ ] `npm run build` clean
- [ ] Verify a thrown exception inside `checkSuspiciousLiqPrice` no longer prevents the other four watchers from running (manual test: throw in dev image and inspect logs)
- [ ] Verify outer `consecutiveFailures` still increments on a real sync-pipeline failure