### PR TITLE
Support multiple monitoring telegram recipients via TELEGRAM_CHAT_IDS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,9 @@ PG_MAX_CLIENTS=10
 
 # Telegram Bot Configuration (optional)
 # TELEGRAM_BOT_TOKEN=5123456789:ABCdefGHIjklMNOpqrsTUVwxyz
-# TELEGRAM_CHAT_ID=123456789
+# Comma-separated list of chat IDs that should receive monitoring alerts.
+# Each operator's private chat-id (or a group id) goes here, no spaces required.
+# TELEGRAM_CHAT_IDS=123456789,987654321
 # TELEGRAM_ALERTS_ENABLED=false
 # ALERT_TIMEFRAME_HOURS=12
 

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -72,8 +72,8 @@ export class AppConfigService {
 		return this.monitoringConfig.telegramBotToken;
 	}
 
-	get telegramChatId(): string | undefined {
-		return this.monitoringConfig.telegramChatId;
+	get telegramChatIds(): string[] | undefined {
+		return this.monitoringConfig.telegramChatIds;
 	}
 
 	get telegramAlertsEnabled(): boolean {

--- a/src/config/monitoring.config.ts
+++ b/src/config/monitoring.config.ts
@@ -1,5 +1,5 @@
 import { registerAs } from '@nestjs/config';
-import { IsString, IsNumber, IsOptional, IsUrl, Min, Max, validateSync, IsBoolean } from 'class-validator';
+import { IsString, IsNumber, IsOptional, IsUrl, Min, Max, validateSync, IsBoolean, IsArray } from 'class-validator';
 import { Transform, plainToClass } from 'class-transformer';
 
 export class MonitoringConfig {
@@ -55,8 +55,9 @@ export class MonitoringConfig {
 	telegramBotToken?: string;
 
 	@IsOptional()
-	@IsString()
-	telegramChatId?: string;
+	@IsArray()
+	@IsString({ each: true })
+	telegramChatIds?: string[];
 
 	@IsOptional()
 	@IsBoolean()
@@ -96,7 +97,9 @@ export default registerAs('monitoring', () => {
 	config.rpcTimeoutMs = parseInt(process.env.RPC_TIMEOUT_MS || '60000');
 
 	config.telegramBotToken = process.env.TELEGRAM_BOT_TOKEN || '';
-	config.telegramChatId = process.env.TELEGRAM_CHAT_ID || '';
+	config.telegramChatIds = process.env.TELEGRAM_CHAT_IDS?.split(',')
+		.map((id) => id.trim())
+		.filter((id) => id.length > 0);
 	config.telegramAlertsEnabled = (process.env.TELEGRAM_ALERTS_ENABLED || 'false').toLowerCase() === 'true';
 	config.alertTimeframeHours = parseInt(process.env.ALERT_TIMEFRAME_HOURS || '12');
 	config.coingeckoApiKey = process.env.COINGECKO_API_KEY || '';

--- a/src/monitoringV2/telegram.service.ts
+++ b/src/monitoringV2/telegram.service.ts
@@ -9,7 +9,7 @@ import { AppConfigService } from 'src/config/config.service';
 export class TelegramService {
 	private readonly logger = new Logger(TelegramService.name);
 	private readonly botToken: string;
-	private readonly chatId: string;
+	private readonly chatIds: string[];
 	private readonly enabled: boolean;
 
 	constructor(
@@ -18,9 +18,12 @@ export class TelegramService {
 		private readonly eventsRepo: EventsRepository
 	) {
 		this.botToken = this.config.telegramBotToken;
-		this.chatId = this.config.telegramChatId;
-		this.enabled = this.config.telegramAlertsEnabled && !!this.botToken && !!this.chatId;
-		this.logger.log(`Telegram notifications are ${this.enabled ? 'ENABLED' : 'DISABLED'}`);
+		this.chatIds = this.config.telegramChatIds ?? [];
+		this.enabled = this.config.telegramAlertsEnabled && !!this.botToken && this.chatIds.length > 0;
+		this.logger.log(
+			`Telegram notifications are ${this.enabled ? 'ENABLED' : 'DISABLED'}` +
+				(this.enabled ? ` (${this.chatIds.length} recipient${this.chatIds.length === 1 ? '' : 's'})` : '')
+		);
 	}
 
 	async sendPendingAlerts(): Promise<void> {
@@ -83,27 +86,39 @@ export class TelegramService {
 		return `${day} at ${time} UTC`;
 	}
 
+	/**
+	 * Deliver to every configured chat. Throws on the first failed delivery so the
+	 * caller can react identically to the previous single-recipient behaviour. Recipients
+	 * are processed sequentially with a small throttle to stay under Telegram's per-bot
+	 * rate limit even when bursting alerts to several operators.
+	 */
 	private async sendMessage(text: string): Promise<void> {
-		const url = `https://api.telegram.org/bot${this.botToken}/sendMessage`;
+		for (let i = 0; i < this.chatIds.length; i++) {
+			const chatId = this.chatIds[i];
+			const url = `https://api.telegram.org/bot${this.botToken}/sendMessage`;
 
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 10000);
-		const response = await fetch(url, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				chat_id: this.chatId,
-				text,
-				parse_mode: 'Markdown',
-				disable_web_page_preview: true,
-			}),
-			signal: controller.signal,
-		});
-		clearTimeout(timeout);
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), 10000);
+			const response = await fetch(url, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					chat_id: chatId,
+					text,
+					parse_mode: 'Markdown',
+					disable_web_page_preview: true,
+				}),
+				signal: controller.signal,
+			});
+			clearTimeout(timeout);
 
-		if (!response.ok) {
-			const error = await response.text();
-			throw new Error(`Telegram API error: ${error}`);
+			if (!response.ok) {
+				const error = await response.text();
+				throw new Error(`Telegram API error for chat ${chatId}: ${error}`);
+			}
+
+			// Throttle between recipients to respect the per-bot rate limit (~30 msg/s).
+			if (i < this.chatIds.length - 1) await this.sleep(50);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Replace the single `TELEGRAM_CHAT_ID` env-var with a comma-separated `TELEGRAM_CHAT_IDS` list. Each operator's chat-id (or a group id) goes in the list; `sendMessage` iterates and delivers to every recipient sequentially with a 50ms throttle between sends.

### Usage

```env
TELEGRAM_CHAT_IDS=123456789,987654321
```

Each operator looks up their own chat-id once (e.g. via `@userinfobot`) and adds it to the list — no Telegram group required, no `/subscribe` polling complexity.

### Why

Issue #91 Punkt 2 calls for breaking the single-recipient single-point-of-failure where one operator's private chat is the only delivery target. With a static op-team (you + Patrick + maybe 1-2 more) a comma-separated env-var is operationally simpler than full self-service polling/`/subscribe`/persistence — same redundancy outcome with a fraction of the code surface.

### Migration

- DFXswiss/server compose updated separately to rename `TELEGRAM_MONITOR_CHAT_ID` → `TELEGRAM_MONITOR_CHAT_IDS` so the same value flows through with no behaviour change initially.
- Additional recipients are added by appending to the list in compose / Vaultwarden.

## Test plan

- [ ] `npm run build` clean
- [ ] On deploy: bootstrap log shows `Telegram notifications are ENABLED (N recipients)`
- [ ] Trigger a critical alert, confirm every chat-id in the list receives it
- [ ] Empty / unset list: bootstrap log shows DISABLED, no send attempts