### PR TITLE
Refuse to start without a CoinGecko config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,11 @@ MAX_BLOCKS_PER_BATCH=1000
 PRICE_CACHE_TTL_MS=120000
 PG_MAX_CLIENTS=10
 
-# CoinGecko Configuration (optional)
+# CoinGecko Configuration (one of the two is required — service refuses to
+# start when neither is set; silent anonymous mode would mask the misconfig
+# and route prices through the IP-shared quota that already proved fragile).
 #
-# Three deployment modes, in priority order:
+# Two deployment modes, in priority order:
 #  1. Caching pricing proxy: set COINGECKO_BASE_URL to the proxy origin, leave
 #     COINGECKO_API_KEY empty. The proxy injects the upstream key itself.
 #       COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
@@ -26,7 +28,6 @@ PG_MAX_CLIENTS=10
 #     COINGECKO_BASE_URL empty. Calls go to pro-api.coingecko.com with
 #     `x-cg-pro-api-key`.
 #       COINGECKO_API_KEY=CG-xxxxxxxxxxxxxxxxxxxxxxxx
-#  3. Anonymous: leave both empty — calls hit api.coingecko.com unauthenticated.
 # COINGECKO_BASE_URL=
 # COINGECKO_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,18 @@ MAX_BLOCKS_PER_BATCH=1000
 PRICE_CACHE_TTL_MS=120000
 PG_MAX_CLIENTS=10
 
-# CoinGecko: the service always talks to the in-cluster pricing proxy, which
-# holds the upstream key and validates upstream errors. Required; the service
-# refuses to start without it.
+# CoinGecko Configuration.
+#
+# COINGECKO_BASE_URL: required. The origin the service calls. Recommended is
+# the in-cluster pricing-proxy (https://github.com/DFXswiss/pricing-proxy),
+# which holds the upstream Pro key and serves a 60 s shared cache. Anything
+# CoinGecko-compatible works (pro-api.coingecko.com, api.coingecko.com, …).
 COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
+#
+# COINGECKO_API_KEY: optional. If set, attached as `x-cg-pro-api-key` to every
+# request. Leave unset when talking to the pricing-proxy (proxy injects its
+# own key) or to the public host anonymously.
+# COINGECKO_API_KEY=
 
 # Telegram Bot Configuration (optional)
 # TELEGRAM_BOT_TOKEN=5123456789:ABCdefGHIjklMNOpqrsTUVwxyz

--- a/.env.example
+++ b/.env.example
@@ -16,20 +16,10 @@ MAX_BLOCKS_PER_BATCH=1000
 PRICE_CACHE_TTL_MS=120000
 PG_MAX_CLIENTS=10
 
-# CoinGecko Configuration (one of the two is required — service refuses to
-# start when neither is set; silent anonymous mode would mask the misconfig
-# and route prices through the IP-shared quota that already proved fragile).
-#
-# Two deployment modes, in priority order:
-#  1. Caching pricing proxy: set COINGECKO_BASE_URL to the proxy origin, leave
-#     COINGECKO_API_KEY empty. The proxy injects the upstream key itself.
-#       COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
-#  2. Direct Pro tier: set COINGECKO_API_KEY to a Pro key, leave
-#     COINGECKO_BASE_URL empty. Calls go to pro-api.coingecko.com with
-#     `x-cg-pro-api-key`.
-#       COINGECKO_API_KEY=CG-xxxxxxxxxxxxxxxxxxxxxxxx
-# COINGECKO_BASE_URL=
-# COINGECKO_API_KEY=
+# CoinGecko: the service always talks to the in-cluster pricing proxy, which
+# holds the upstream key and validates upstream errors. Required; the service
+# refuses to start without it.
+COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
 
 # Telegram Bot Configuration (optional)
 # TELEGRAM_BOT_TOKEN=5123456789:ABCdefGHIjklMNOpqrsTUVwxyz

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ cp .env.example .env
 # - DATABASE_URL: PostgreSQL connection string
 # - RPC_URL: Ethereum mainnet RPC endpoint
 # - BLOCKCHAIN_ID: Must be 1 (Ethereum mainnet)
+# - COINGECKO_BASE_URL: required, see "CoinGecko" section below
 
 # Generate Prisma client
 npm run prisma:generate
@@ -66,6 +67,38 @@ docker rm -f deuro-test
 ## API Documentation
 
 Swagger documentation available at: `http://localhost:3001/swagger`
+
+## CoinGecko
+
+The monitoring service needs a CoinGecko-compatible endpoint for USD/EUR
+and USD/CHF FX rates (drives EUR-denominated price conversions and the
+staleness watchdog) and the daily Pro quota probe. Configuration is two
+env vars:
+
+| Var | Required | Purpose |
+|---|---|---|
+| `COINGECKO_BASE_URL` | yes | Origin the service calls. |
+| `COINGECKO_API_KEY` | no | Attached as the `x-cg-pro-api-key` header on every request when set. |
+
+The recommended deployment is the
+[**pricing-proxy**](https://github.com/DFXswiss/pricing-proxy) — a small
+caching reverse-proxy in front of CoinGecko Pro. It holds the upstream key,
+serves a 60 s shared cache, validates upstream error envelopes, and
+coalesces concurrent identical requests. When you use the proxy:
+
+```env
+COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
+# COINGECKO_API_KEY left unset — the proxy injects its own key
+```
+
+Without the proxy you can talk to CoinGecko directly:
+
+```env
+COINGECKO_BASE_URL=https://pro-api.coingecko.com
+COINGECKO_API_KEY=CG-xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+The service refuses to start without `COINGECKO_BASE_URL`.
 
 ## Deployment
 

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MonitoringConfig } from './monitoring.config';
 
-const SENSITIVE_KEYS = new Set<string>(['rpcUrl', 'databaseUrl', 'telegramBotToken', 'coingeckoApiKey']);
+const SENSITIVE_KEYS = new Set<string>(['rpcUrl', 'databaseUrl', 'telegramBotToken']);
 
 function redactConfig<T>(config: T): T {
 	return walkRedact(config, '') as T;
@@ -82,10 +82,6 @@ export class AppConfigService {
 
 	get alertTimeframeHours(): number {
 		return this.monitoringConfig.alertTimeframeHours || 12;
-	}
-
-	get coingeckoApiKey(): string | undefined {
-		return this.monitoringConfig.coingeckoApiKey || undefined;
 	}
 
 	get coingeckoBaseUrl(): string | undefined {

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MonitoringConfig } from './monitoring.config';
 
-const SENSITIVE_KEYS = new Set<string>(['rpcUrl', 'databaseUrl', 'telegramBotToken']);
+const SENSITIVE_KEYS = new Set<string>(['rpcUrl', 'databaseUrl', 'telegramBotToken', 'coingeckoApiKey']);
 
 function redactConfig<T>(config: T): T {
 	return walkRedact(config, '') as T;
@@ -82,6 +82,10 @@ export class AppConfigService {
 
 	get alertTimeframeHours(): number {
 		return this.monitoringConfig.alertTimeframeHours || 12;
+	}
+
+	get coingeckoApiKey(): string | undefined {
+		return this.monitoringConfig.coingeckoApiKey || undefined;
 	}
 
 	get coingeckoBaseUrl(): string | undefined {

--- a/src/config/monitoring.config.ts
+++ b/src/config/monitoring.config.ts
@@ -69,10 +69,6 @@ export class MonitoringConfig {
 
 	@IsOptional()
 	@IsString()
-	coingeckoApiKey?: string;
-
-	@IsOptional()
-	@IsString()
 	coingeckoBaseUrl?: string;
 
 	@IsOptional()
@@ -103,7 +99,6 @@ export default registerAs('monitoring', () => {
 	config.telegramGroupsJson = process.env.TELEGRAM_GROUPS_JSON;
 	config.telegramAlertsEnabled = (process.env.TELEGRAM_ALERTS_ENABLED || 'false').toLowerCase() === 'true';
 	config.alertTimeframeHours = parseInt(process.env.ALERT_TIMEFRAME_HOURS || '12');
-	config.coingeckoApiKey = process.env.COINGECKO_API_KEY || '';
 	config.coingeckoBaseUrl = process.env.COINGECKO_BASE_URL || '';
 	config.environment = process.env.ENVIRONMENT?.toLowerCase();
 	config.chain = process.env.CHAIN;

--- a/src/config/monitoring.config.ts
+++ b/src/config/monitoring.config.ts
@@ -73,6 +73,10 @@ export class MonitoringConfig {
 
 	@IsOptional()
 	@IsString()
+	coingeckoApiKey?: string;
+
+	@IsOptional()
+	@IsString()
 	environment?: string;
 
 	@IsOptional()
@@ -100,6 +104,7 @@ export default registerAs('monitoring', () => {
 	config.telegramAlertsEnabled = (process.env.TELEGRAM_ALERTS_ENABLED || 'false').toLowerCase() === 'true';
 	config.alertTimeframeHours = parseInt(process.env.ALERT_TIMEFRAME_HOURS || '12');
 	config.coingeckoBaseUrl = process.env.COINGECKO_BASE_URL || '';
+	config.coingeckoApiKey = process.env.COINGECKO_API_KEY || '';
 	config.environment = process.env.ENVIRONMENT?.toLowerCase();
 	config.chain = process.env.CHAIN;
 

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -71,8 +71,8 @@ export class PriceService {
 		private readonly telegramService: TelegramService
 	) {
 		this.CACHE_TTL_MS = this.appConfigService.priceCacheTtlMs;
-		if (!this.appConfigService.coingeckoBaseUrl && !this.appConfigService.coingeckoApiKey) {
-			throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
+		if (!this.appConfigService.coingeckoBaseUrl) {
+			throw new Error('COINGECKO_BASE_URL is not set');
 		}
 	}
 
@@ -205,31 +205,17 @@ export class PriceService {
 	}
 
 	/**
-	 * Resolve which CoinGecko endpoint and authentication header to use.
-	 *
-	 * Two modes, in priority order:
-	 *  1. `COINGECKO_BASE_URL` set → trust the caller (typically a pricing proxy
-	 *     that injects the upstream key itself); send no auth header.
-	 *  2. `COINGECKO_API_KEY` set → Pro tier: pro-api.coingecko.com with
-	 *     `x-cg-pro-api-key`.
-	 *
-	 * The constructor refuses to start the service when neither is set, so
-	 * this method does not need to fall back to the anonymous public
-	 * endpoint — silent anonymous mode would mask a misconfiguration and
-	 * route prices through the IP-shared quota that already proved fragile.
+	 * Resolve the CoinGecko endpoint. The service is always pointed at the
+	 * in-cluster pricing proxy via `COINGECKO_BASE_URL`; the proxy holds the
+	 * upstream key and validates upstream errors. The constructor refuses to
+	 * start without that env var, so this method only has the one path.
 	 */
 	private resolveCoingeckoEndpoint(): CoingeckoEndpoint {
-		const headers: Record<string, string> = { accept: 'application/json' };
-		const explicitBase = this.appConfigService.coingeckoBaseUrl;
-		if (explicitBase) {
-			return { baseUrl: explicitBase, headers };
+		const baseUrl = this.appConfigService.coingeckoBaseUrl;
+		if (!baseUrl) {
+			throw new Error('COINGECKO_BASE_URL is not set');
 		}
-		const apiKey = this.appConfigService.coingeckoApiKey;
-		if (apiKey) {
-			headers['x-cg-pro-api-key'] = apiKey;
-			return { baseUrl: 'https://pro-api.coingecko.com', headers };
-		}
-		throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
+		return { baseUrl, headers: { accept: 'application/json' } };
 	}
 
 	private async fetchFxRates(
@@ -304,20 +290,12 @@ export class PriceService {
 	}
 
 	/**
-	 * Daily probe of /api/v3/key. Emits a critical alert when the monthly
-	 * remaining call credit drops below QUOTA_REMAINING_ALERT_THRESHOLD.
-	 *
-	 * Routes through the same endpoint resolution as price calls so a proxy
-	 * deployment (key held only by the proxy) is still covered. Skipped only
-	 * when the service runs fully anonymous (no proxy and no key) — in that
-	 * case there is no Pro account to monitor.
+	 * Daily probe of /api/v3/key through the pricing proxy. Emits a critical
+	 * alert when the monthly remaining call credit drops below
+	 * QUOTA_REMAINING_ALERT_THRESHOLD.
 	 */
 	@Cron(CronExpression.EVERY_DAY_AT_NOON)
 	async checkCoingeckoQuota(): Promise<void> {
-		const explicitBase = this.appConfigService.coingeckoBaseUrl;
-		const apiKey = this.appConfigService.coingeckoApiKey;
-		if (!explicitBase && !apiKey) return;
-
 		try {
 			const { baseUrl, headers } = this.resolveCoingeckoEndpoint();
 			const response = await axios.get<CoingeckoKeyInfo>(`${baseUrl}/api/v3/key`, {

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -205,17 +205,30 @@ export class PriceService {
 	}
 
 	/**
-	 * Resolve the CoinGecko endpoint. The service is always pointed at the
-	 * in-cluster pricing proxy via `COINGECKO_BASE_URL`; the proxy holds the
-	 * upstream key and validates upstream errors. The constructor refuses to
-	 * start without that env var, so this method only has the one path.
+	 * Resolve the CoinGecko endpoint.
+	 *
+	 * `COINGECKO_BASE_URL` is required and points at the origin the service
+	 * talks to — typically the in-cluster pricing-proxy
+	 * (https://github.com/DFXswiss/pricing-proxy), but any CoinGecko-compatible
+	 * origin works (e.g. `https://pro-api.coingecko.com` or
+	 * `https://api.coingecko.com`).
+	 *
+	 * `COINGECKO_API_KEY` is optional and is attached as the
+	 * `x-cg-pro-api-key` header on every request when set. Leave it unset when
+	 * talking to the pricing-proxy (the proxy injects its own key) or when
+	 * hitting the public host anonymously.
 	 */
 	private resolveCoingeckoEndpoint(): CoingeckoEndpoint {
 		const baseUrl = this.appConfigService.coingeckoBaseUrl;
 		if (!baseUrl) {
 			throw new Error('COINGECKO_BASE_URL is not set');
 		}
-		return { baseUrl, headers: { accept: 'application/json' } };
+		const headers: Record<string, string> = { accept: 'application/json' };
+		const apiKey = this.appConfigService.coingeckoApiKey;
+		if (apiKey) {
+			headers['x-cg-pro-api-key'] = apiKey;
+		}
+		return { baseUrl, headers };
 	}
 
 	private async fetchFxRates(

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -71,6 +71,9 @@ export class PriceService {
 		private readonly telegramService: TelegramService
 	) {
 		this.CACHE_TTL_MS = this.appConfigService.priceCacheTtlMs;
+		if (!this.appConfigService.coingeckoBaseUrl && !this.appConfigService.coingeckoApiKey) {
+			throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
+		}
 	}
 
 	async getTokenPricesInEur(addresses: string[]): Promise<{ [key: string]: string }> {
@@ -204,12 +207,16 @@ export class PriceService {
 	/**
 	 * Resolve which CoinGecko endpoint and authentication header to use.
 	 *
-	 * Three modes, in priority order:
+	 * Two modes, in priority order:
 	 *  1. `COINGECKO_BASE_URL` set → trust the caller (typically a pricing proxy
 	 *     that injects the upstream key itself); send no auth header.
 	 *  2. `COINGECKO_API_KEY` set → Pro tier: pro-api.coingecko.com with
 	 *     `x-cg-pro-api-key`.
-	 *  3. Otherwise → unauthenticated public endpoint.
+	 *
+	 * The constructor refuses to start the service when neither is set, so
+	 * this method does not need to fall back to the anonymous public
+	 * endpoint — silent anonymous mode would mask a misconfiguration and
+	 * route prices through the IP-shared quota that already proved fragile.
 	 */
 	private resolveCoingeckoEndpoint(): CoingeckoEndpoint {
 		const headers: Record<string, string> = { accept: 'application/json' };
@@ -222,7 +229,7 @@ export class PriceService {
 			headers['x-cg-pro-api-key'] = apiKey;
 			return { baseUrl: 'https://pro-api.coingecko.com', headers };
 		}
-		return { baseUrl: 'https://api.coingecko.com', headers };
+		throw new Error('CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY');
 	}
 
 	private async fetchFxRates(


### PR DESCRIPTION
## Summary
Follow-up to #64. The resolver carried a silent third branch that returned \`https://api.coingecko.com\` (anonymous public host) when neither \`COINGECKO_BASE_URL\` nor \`COINGECKO_API_KEY\` was set. That is exactly the shape of "no fallbacks" we want to avoid: a misconfigured service would happily come up, route every call through the IP-shared anonymous quota, and surface only later as sporadic 429s.

- Constructor now throws on missing config: \`CoinGecko is not configured: set COINGECKO_BASE_URL or COINGECKO_API_KEY\`.
- Resolver no longer has an anonymous branch; only proxy and direct-Pro paths remain.
- \`.env.example\` updated to reflect that one of the two is required.

## Test plan
- [ ] \`npm run build\` passes locally.
- [ ] Start the container with neither env var set → bootstrap fails with the new error message, container stays in restart-loop visibility.
- [ ] Start with \`COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko\` → boots, FX fetch succeeds.