### PR TITLE
Route GeckoTerminal via pricing-proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,12 +31,14 @@ COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
 
 # GeckoTerminal Configuration.
 #
-# GECKOTERMINAL_BASE_URL: optional. The origin used for GeckoTerminal token
+# GECKOTERMINAL_BASE_URL: required. The origin used for GeckoTerminal token
 # price calls. Recommended is the in-cluster pricing-proxy
 # (https://github.com/DFXswiss/pricing-proxy), which gives cache, coalescing
-# and validation on top of the shared free-tier 30 req/min quota. Leave unset
-# to call api.geckoterminal.com directly.
-# GECKOTERMINAL_BASE_URL=http://pricing-proxy:8080/geckoterminal
+# and validation on top of the shared free-tier 30 req/min quota. Anything
+# GeckoTerminal-compatible works (api.geckoterminal.com directly is fine for
+# single-consumer setups, but the free-tier quota is shared across the whole
+# host IP).
+GECKOTERMINAL_BASE_URL=http://pricing-proxy:8080/geckoterminal
 
 # Telegram Bot Configuration (optional)
 # TELEGRAM_BOT_TOKEN=5123456789:ABCdefGHIjklMNOpqrsTUVwxyz

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,15 @@ COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
 # own key) or to the public host anonymously.
 # COINGECKO_API_KEY=
 
+# GeckoTerminal Configuration.
+#
+# GECKOTERMINAL_BASE_URL: optional. The origin used for GeckoTerminal token
+# price calls. Recommended is the in-cluster pricing-proxy
+# (https://github.com/DFXswiss/pricing-proxy), which gives cache, coalescing
+# and validation on top of the shared free-tier 30 req/min quota. Leave unset
+# to call api.geckoterminal.com directly.
+# GECKOTERMINAL_BASE_URL=http://pricing-proxy:8080/geckoterminal
+
 # Telegram Bot Configuration (optional)
 # TELEGRAM_BOT_TOKEN=5123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 # Path to the persisted subscribers file. Each operator subscribes themselves by

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -92,6 +92,10 @@ export class AppConfigService {
 		return this.monitoringConfig.coingeckoBaseUrl || undefined;
 	}
 
+	get geckoTerminalBaseUrl(): string | undefined {
+		return this.monitoringConfig.geckoTerminalBaseUrl || undefined;
+	}
+
 	get environment(): string | undefined {
 		return this.monitoringConfig.environment;
 	}

--- a/src/config/monitoring.config.ts
+++ b/src/config/monitoring.config.ts
@@ -77,6 +77,10 @@ export class MonitoringConfig {
 
 	@IsOptional()
 	@IsString()
+	geckoTerminalBaseUrl?: string;
+
+	@IsOptional()
+	@IsString()
 	environment?: string;
 
 	@IsOptional()
@@ -105,6 +109,7 @@ export default registerAs('monitoring', () => {
 	config.alertTimeframeHours = parseInt(process.env.ALERT_TIMEFRAME_HOURS || '12');
 	config.coingeckoBaseUrl = process.env.COINGECKO_BASE_URL || '';
 	config.coingeckoApiKey = process.env.COINGECKO_API_KEY || '';
+	config.geckoTerminalBaseUrl = process.env.GECKOTERMINAL_BASE_URL || '';
 	config.environment = process.env.ENVIRONMENT?.toLowerCase();
 	config.chain = process.env.CHAIN;
 

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -74,6 +74,9 @@ export class PriceService {
 		if (!this.appConfigService.coingeckoBaseUrl) {
 			throw new Error('COINGECKO_BASE_URL is not set');
 		}
+		if (!this.appConfigService.geckoTerminalBaseUrl) {
+			throw new Error('GECKOTERMINAL_BASE_URL is not set');
+		}
 	}
 
 	async getTokenPricesInEur(addresses: string[]): Promise<{ [key: string]: string }> {
@@ -81,15 +84,15 @@ export class PriceService {
 		const standardAddresses = addresses.filter((addr) => !this.isSpecialToken(addr));
 
 		// Fetch everything in parallel for better performance
-		const [specialPrices, coinGeckoPrices, usdToEur] = await Promise.all([
+		const [specialPrices, geckoTerminalPrices, usdToEur] = await Promise.all([
 			this.getSpecialTokenPrices(requestedSpecialAddresses),
-			this.getCoinGeckoPricesInUSD(standardAddresses),
+			this.getGeckoTerminalPricesInUSD(standardAddresses),
 			this.getUsdToEur(),
 		]);
 
 		// Convert USD prices to EUR
 		const eurPrices: { [key: string]: string } = {};
-		for (const [address, price] of Object.entries(coinGeckoPrices)) {
+		for (const [address, price] of Object.entries(geckoTerminalPrices)) {
 			eurPrices[address] = (Number(price) * usdToEur).toString();
 		}
 
@@ -101,7 +104,7 @@ export class PriceService {
 	 * @param addresses Array of token addresses to fetch prices for
 	 * @returns Object mapping addresses to prices in USD
 	 */
-	private async getCoinGeckoPricesInUSD(addresses: string[]): Promise<{ [key: string]: string }> {
+	private async getGeckoTerminalPricesInUSD(addresses: string[]): Promise<{ [key: string]: string }> {
 		if (addresses.length === 0) return {};
 
 		const cached = this.getFromCache(addresses);
@@ -111,7 +114,7 @@ export class PriceService {
 			return cached;
 		}
 
-		const baseUrl = this.appConfigService.geckoTerminalBaseUrl ?? 'https://api.geckoterminal.com';
+		const baseUrl = this.appConfigService.geckoTerminalBaseUrl;
 
 		try {
 			const response = await axios.get<TokenPrice>(

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -111,9 +111,11 @@ export class PriceService {
 			return cached;
 		}
 
+		const baseUrl = this.appConfigService.geckoTerminalBaseUrl ?? 'https://api.geckoterminal.com';
+
 		try {
 			const response = await axios.get<TokenPrice>(
-				`https://api.geckoterminal.com/api/v2/simple/networks/eth/token_price/${remaining.map((a) => a.toLowerCase()).join(',')}`,
+				`${baseUrl}/api/v2/simple/networks/eth/token_price/${remaining.map((a) => a.toLowerCase()).join(',')}`,
 				{
 					headers: { accept: 'application/json' },
 					timeout: 10000, // 10 second timeout


### PR DESCRIPTION
## Summary

Adds the **required** \`GECKOTERMINAL_BASE_URL\` env var to point the GeckoTerminal upstream at the in-cluster pricing-proxy ([DFXswiss/pricing-proxy](https://github.com/DFXswiss/pricing-proxy)) instead of \`api.geckoterminal.com\` directly. Mirrors the \`COINGECKO_BASE_URL\` plumbing from #31 — same construction-time hard-fail, same .env wording, same getter shape.

## Why

GeckoTerminal's free tier shares a single 30 req/min IP quota across every consumer on the host. Three monitoring stacks (d-EURO, JuiceDollar testnet, JuiceDollar mainnet) plus restart-bursts already produce visible 429s on dfxdev:

\`\`\`
deuro-deuro-monitoring-1 | ERROR [PriceService] AxiosError: Request failed with status code 429
deuro-deuro-monitoring-1 | WARN  [PriceService] Returning expired cached prices due to API error
\`\`\`

The pricing-proxy now exposes a \`/geckoterminal/\` route ([pricing-proxy#3](https://github.com/DFXswiss/pricing-proxy/pull/3)) with the same 60 s shared cache, request coalescing and validation pipeline already in front of CoinGecko Pro. Pointing this service at it collapses the three independent streams into one upstream call per 60 s.

## What changes

- \`src/config/monitoring.config.ts\` — new \`geckoTerminalBaseUrl?: string\` field plumbed from \`GECKOTERMINAL_BASE_URL\`.
- \`src/config/config.service.ts\` — getter, same shape as \`coingeckoBaseUrl\`.
- \`src/monitoringV2/price.service.ts\` —
  - Constructor hard-fails when \`GECKOTERMINAL_BASE_URL\` is unset, same as for \`COINGECKO_BASE_URL\`. No silent anonymous fallback.
  - Misnomer fix: \`getCoinGeckoPricesInUSD\` → \`getGeckoTerminalPricesInUSD\` (and the local \`coinGeckoPrices\` variable in \`getTokenPricesInEur\`). The function has always called \`api.geckoterminal.com\`, not CoinGecko — the name was a relic from before the GT path was split out. Matches the helper name already in use in the downstream fork at \`JuiceDollar/monitoring\`.
- \`.env.example\` — documents the new var as required, parallel to \`COINGECKO_BASE_URL\`.

## Breaking — rollout order matters

\`GECKOTERMINAL_BASE_URL\` is required. A container started without it now refuses to construct and the deploy will roll back. The server-side compose update on \`DFXswiss/server\` (adding the env to \`deuro-monitoring\` on dfxdev + dfxprd) must therefore be in place **before** the Auto-Release-PR for this repo lands on \`main\` and the \`:latest\` image rebuilds.

Recommended order:

1. Merge this PR → \`:beta\` rebuilds. dfxdev's \`deuro-monitoring\` stack will not auto-deploy because the env var isn't set yet; that's fine, the existing container keeps serving.
2. Land the server-repo compose change adding \`GECKOTERMINAL_BASE_URL: http://pricing-proxy:8080/geckoterminal\` to \`deuro-monitoring\` on dfxdev + dfxprd, plus the auto-release PR to \`main\`. After that deploys, the existing \`:latest\` container restarts with the env set and keeps working (env is read at startup, old code just ignores the var).
3. Approve the Auto-Release-PR for this repo (develop → main). \`:latest\` rebuilds. Next \`deuro-monitoring\` deploy picks up the new image, constructor sees the env, traffic now flows through the proxy.

## Test plan

- [x] CI green (build + lint)
- [ ] After server-repo compose change lands on dfxdev: existing \`deuro-monitoring\` container restarts cleanly with \`GECKOTERMINAL_BASE_URL\` set; logs still show \`Fetched prices for N tokens from GeckoTerminal\` (old code, still direct path).
- [ ] After this PR's auto-release lands on main and the resulting \`:latest\` deploys: pricing-proxy logs on dfxdev show \`/geckoterminal/api/v2/...\` traffic from the \`deuro-monitoring\` container IP, and the 429 lines stop.
- [ ] Same verification on dfxprd after the prd-side compose + deploy.