### PR TITLE
Remove daily CoinGecko quota probe (now owned by pricing-proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ Swagger documentation available at: `http://localhost:3001/swagger`
 ## CoinGecko
 
 The monitoring service needs a CoinGecko-compatible endpoint for USD/EUR
-and USD/CHF FX rates (drives EUR-denominated price conversions and the
-staleness watchdog) and the daily Pro quota probe. Configuration is two
-env vars:
+and USD/CHF FX rates — they drive EUR-denominated price conversions and
+the staleness watchdog. Configuration is two env vars:
 
 | Var | Required | Purpose |
 |---|---|---|

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -39,17 +39,8 @@ interface CoingeckoEndpoint {
 	headers: Record<string, string>;
 }
 
-interface CoingeckoKeyInfo {
-	plan?: string;
-	monthly_call_credit?: number;
-	current_total_monthly_calls?: number;
-	current_remaining_monthly_calls?: number;
-}
-
 const STALENESS_ALERT_THRESHOLD_MS = 60 * 60 * 1000;
 const STALENESS_ALERT_REPEAT_MS = 6 * 60 * 60 * 1000;
-const QUOTA_REMAINING_ALERT_THRESHOLD = 25_000;
-const QUOTA_ALERT_REPEAT_MS = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class PriceService {
@@ -63,7 +54,6 @@ export class PriceService {
 	// suppress the alert indefinitely.
 	private fxLastSuccessMs: number = Date.now();
 	private fxStalenessAlertedAt: number | null = null;
-	private quotaAlertedAt: number | null = null;
 
 	constructor(
 		private readonly providerService: ProviderService,
@@ -305,41 +295,6 @@ export class PriceService {
 			`USD/EUR + USD/CHF FX rates have not refreshed for ${minutes} min — ` +
 				`EUR-denominated price conversions are running on stale reference.`
 		);
-	}
-
-	/**
-	 * Daily probe of /api/v3/key through the pricing proxy. Emits a critical
-	 * alert when the monthly remaining call credit drops below
-	 * QUOTA_REMAINING_ALERT_THRESHOLD.
-	 */
-	@Cron(CronExpression.EVERY_DAY_AT_NOON)
-	async checkCoingeckoQuota(): Promise<void> {
-		try {
-			const { baseUrl, headers } = this.resolveCoingeckoEndpoint();
-			const response = await axios.get<CoingeckoKeyInfo>(`${baseUrl}/api/v3/key`, {
-				headers,
-				timeout: 10000,
-			});
-			const { current_remaining_monthly_calls: remaining, monthly_call_credit: credit } = response.data;
-			if (typeof remaining !== 'number' || typeof credit !== 'number' || credit <= 0) return;
-
-			const pct = Math.round((remaining / credit) * 100);
-			this.logger.log(`CoinGecko quota: ${remaining} of ${credit} calls remaining (${pct}%)`);
-
-			if (remaining >= QUOTA_REMAINING_ALERT_THRESHOLD) {
-				this.quotaAlertedAt = null;
-				return;
-			}
-			if (this.quotaAlertedAt && Date.now() - this.quotaAlertedAt < QUOTA_ALERT_REPEAT_MS) return;
-
-			this.quotaAlertedAt = Date.now();
-			await this.telegramService.sendCriticalAlert(
-				`CoinGecko monthly quota almost exhausted: ${remaining.toLocaleString()} of ` +
-					`${credit.toLocaleString()} calls remaining (${pct}%).`
-			);
-		} catch (error) {
-			this.logger.warn(`CoinGecko quota probe failed: ${error.message ?? error}`);
-		}
 	}
 
 	// Cache management methods


### PR DESCRIPTION
## Summary

The pricing-proxy now owns CoinGecko quota observation end-to-end (DFXswiss/pricing-proxy PR #7 + #9). It probes `/api/v3/key` every 30 min and alerts via the dedicated `@dfx_pricing_proxy_bot` at 80 % (warning) and 95 % (critical) of the monthly credit, with a recovery message when usage drops below 80 % again.

That makes this service's daily probe redundant — and worse, prone to duplicate or out-of-sync alerts. Remove it cleanly:

- Drop `@Cron(EVERY_DAY_AT_NOON) checkCoingeckoQuota()` (~34 lines).
- Drop the `quotaAlertedAt` state field, the `QUOTA_REMAINING_ALERT_THRESHOLD` and `QUOTA_ALERT_REPEAT_MS` constants, and the unused `CoingeckoKeyInfo` interface.
- Update the README's "CoinGecko" section to drop the "daily Pro quota probe" clause; the FX staleness watchdog stays.

Nothing else in the monitor depends on the removed code. The FX rate fetcher (`fetchFxRates`), staleness watchdog (`checkFxStaleness`), and the cache plumbing are untouched.

## Test plan

- [ ] `yarn build` (note: pre-existing TS errors in `api/api.controller.ts` for `PositionState`/`Token` Prisma imports are unrelated)
- [ ] After deploy: no more `CoinGecko quota: …` log lines from this service; pricing-proxy still emits its own heartbeat
- [ ] Verify no consumer of the deleted symbols exists (`grep -r checkCoingeckoQuota\\|CoingeckoKeyInfo\\|QUOTA_REMAINING_ALERT_THRESHOLD .` returns nothing under `src/`)