### PR TITLE
Pricing + contract-registry correctness fixes

### DIFF
--- a/src/monitoringV2/contract.service.ts
+++ b/src/monitoringV2/contract.service.ts
@@ -100,7 +100,7 @@ export class ContractService {
 			);
 		}
 
-		await this.contractRepo.createMany(coreContracts);
+		await this.contractRepo.upsertCore(coreContracts);
 		this.logger.log(`Registry initialized with ${coreContracts.length} core contracts`);
 		this.logger.log(`Registered addresses: ${coreContracts.map((c) => c.address).join(', ')}`);
 	}

--- a/src/monitoringV2/price.service.ts
+++ b/src/monitoringV2/price.service.ts
@@ -106,36 +106,26 @@ export class PriceService {
 
 		const baseUrl = this.appConfigService.geckoTerminalBaseUrl;
 
-		try {
-			const response = await axios.get<TokenPrice>(
-				`${baseUrl}/api/v2/simple/networks/eth/token_price/${remaining.map((a) => a.toLowerCase()).join(',')}`,
-				{
-					headers: { accept: 'application/json' },
-					timeout: 10000, // 10 second timeout
-				}
-			);
-
-			const apiPrices = response.data.data.attributes.token_prices;
-			const normalizedPrices: { [key: string]: string } = {};
-			for (const inputAddress of remaining) {
-				const price = apiPrices[inputAddress.toLowerCase()];
-				if (price) {
-					normalizedPrices[inputAddress] = price;
-					this.setCache(inputAddress, price);
-				}
+		const response = await axios.get<TokenPrice>(
+			`${baseUrl}/api/v2/simple/networks/eth/token_price/${remaining.map((a) => a.toLowerCase()).join(',')}`,
+			{
+				headers: { accept: 'application/json' },
+				timeout: 10000, // 10 second timeout
 			}
+		);
 
-			this.logger.log(`Fetched prices for ${Object.keys(normalizedPrices).length} tokens from GeckoTerminal`);
-			return { ...cached, ...normalizedPrices };
-		} catch (error) {
-			this.logger.error('Failed to fetch token prices from GeckoTerminal:', error);
-			if (cached) {
-				this.logger.warn('Returning expired cached prices due to API error');
-				return cached;
+		const apiPrices = response.data.data.attributes.token_prices;
+		const normalizedPrices: { [key: string]: string } = {};
+		for (const inputAddress of remaining) {
+			const price = apiPrices[inputAddress.toLowerCase()];
+			if (price) {
+				normalizedPrices[inputAddress] = price;
+				this.setCache(inputAddress, price);
 			}
-
-			return {};
 		}
+
+		this.logger.log(`Fetched prices for ${Object.keys(normalizedPrices).length} tokens from GeckoTerminal`);
+		return { ...cached, ...normalizedPrices };
 	}
 
 	private async getSpecialTokenPrices(requestedAddresses: string[]): Promise<{ [key: string]: string }> {
@@ -191,7 +181,7 @@ export class PriceService {
 		// Deduplicate concurrent requests
 		if (this.pendingFxRates) return this.pendingFxRates;
 
-		this.pendingFxRates = this.fetchFxRates(eurCached, chfCached);
+		this.pendingFxRates = this.fetchFxRates();
 		try {
 			return await this.pendingFxRates;
 		} finally {
@@ -226,49 +216,28 @@ export class PriceService {
 		return { baseUrl, headers };
 	}
 
-	private async fetchFxRates(
-		eurCached: PriceCacheEntry | undefined,
-		chfCached: PriceCacheEntry | undefined
-	): Promise<{ eur: number; chf: number }> {
-		try {
-			const { baseUrl, headers } = this.resolveCoingeckoEndpoint();
-			const response = await axios.get(`${baseUrl}/api/v3/simple/price?ids=usd&vs_currencies=eur,chf`, {
-				headers,
-				timeout: 10000,
-			});
+	private async fetchFxRates(): Promise<{ eur: number; chf: number }> {
+		const { baseUrl, headers } = this.resolveCoingeckoEndpoint();
+		const response = await axios.get(`${baseUrl}/api/v3/simple/price?ids=usd&vs_currencies=eur,chf`, {
+			headers,
+			timeout: 10000,
+		});
 
-			const eur = Number(response.data.usd.eur);
-			const chf = Number(response.data.usd.chf);
+		const eur = Number(response.data?.usd?.eur);
+		const chf = Number(response.data?.usd?.chf);
 
-			if (Number.isNaN(eur) || Number.isNaN(chf)) {
-				this.logger.error('CoinGecko returned non-numeric FX rates', response.data);
-				return {
-					eur: !Number.isNaN(eur) ? eur : eurCached ? Number(eurCached.value) : 1,
-					chf: !Number.isNaN(chf) ? chf : chfCached ? Number(chfCached.value) : 1,
-				};
-			}
-
-			const now = Date.now();
-			this.priceCache.set('usd-eur-rate', { value: String(eur), timestamp: now });
-			this.priceCache.set('usd-chf-rate', { value: String(chf), timestamp: now });
-			this.fxLastSuccessMs = now;
-			this.fxStalenessAlertedAt = null;
-
-			this.logger.debug(`FX rates: USD/EUR=${eur}, USD/CHF=${chf}`);
-			return { eur, chf };
-		} catch (error) {
-			this.logger.error('Failed to fetch FX rates:', error.message || error);
-
-			const eur = eurCached ? Number(eurCached.value) : 1;
-			const chf = chfCached ? Number(chfCached.value) : 1;
-
-			// Refresh cache timestamps so we don't retry on every call while rate-limited
-			const now = Date.now();
-			this.priceCache.set('usd-eur-rate', { value: String(eur), timestamp: now });
-			this.priceCache.set('usd-chf-rate', { value: String(chf), timestamp: now });
-
-			return { eur, chf };
+		if (!Number.isFinite(eur) || !Number.isFinite(chf) || eur <= 0 || chf <= 0) {
+			throw new Error(`CoinGecko returned invalid FX rates: usd.eur=${response.data?.usd?.eur}, usd.chf=${response.data?.usd?.chf}`);
 		}
+
+		const now = Date.now();
+		this.priceCache.set('usd-eur-rate', { value: String(eur), timestamp: now });
+		this.priceCache.set('usd-chf-rate', { value: String(chf), timestamp: now });
+		this.fxLastSuccessMs = now;
+		this.fxStalenessAlertedAt = null;
+
+		this.logger.debug(`FX rates: USD/EUR=${eur}, USD/CHF=${chf}`);
+		return { eur, chf };
 	}
 
 	private isSpecialToken(address: string): boolean {

--- a/src/monitoringV2/prisma/repositories/contract.repository.ts
+++ b/src/monitoringV2/prisma/repositories/contract.repository.ts
@@ -30,6 +30,28 @@ export class ContractRepository {
 		}
 	}
 
+	// Core contracts are the canonical, hard-coded protocol addresses from
+	// @deuro/eurocoin. Their `type` is authoritative and must override any
+	// earlier classification (e.g. a Savings deployed via MinterApplied was
+	// first persisted as generic MINTER, then later promoted to SAVINGS_V3
+	// once the package shipped its address). Use upsert so re-registration
+	// corrects the type instead of being silently skipped.
+	async upsertCore(contracts: Contract[]): Promise<void> {
+		if (contracts.length === 0) return;
+
+		for (const contract of contracts) {
+			const address = contract.address.toLowerCase();
+			const metadata = contract.metadata || {};
+			await this.prisma.contract.upsert({
+				where: { address },
+				create: { address, type: contract.type, timestamp: contract.timestamp, metadata },
+				update: { type: contract.type, metadata },
+			});
+		}
+
+		this.logger.log(`Upserted ${contracts.length} core contracts`);
+	}
+
 	async findAll(): Promise<Contract[]> {
 		try {
 			const contracts = await this.prisma.contract.findMany({


### PR DESCRIPTION
## Summary

Two correctness fixes in the monitoring service surfaced by recent prd logs:

### 1. Stale / fabricated prices on upstream failure (`price.service.ts`)
`PriceService` masked GeckoTerminal and CoinGecko failures and kept serving wrong values:

- GeckoTerminal errors silently returned the fresh-cache subset, dropping all uncovered tokens.
- CoinGecko FX errors fell back to `usdToEur=usdToChf=1` and **rewrote the cache timestamp to `now`** — a stale or fabricated rate was then served as fresh for a full `CACHE_TTL_MS` window.

This violates the rule that pricing must fail loud rather than return wrong data. The catch-all fallbacks are removed; errors propagate to the 5-minute monitoring cycle, which already has consecutive-failure escalation. The FX validity check is also tightened to reject zero/negative or non-finite rates.

### 2. Core contracts persisted with stale `MINTER` type (`contract.service.ts`, `contract.repository.ts`)
`registerCoreContracts` used `createMany({ skipDuplicates: true })`. The V3 Savings `0x760233b90e45d186A9A98E911B115F7F4B90d3D9` was first seen as a `MinterApplied` event and persisted as generic `MINTER`. When the `@deuro/eurocoin` release later shipped the address as `ADDRESS[chainId].savings` (= `SAVINGS_V3`), the row was never updated and the contract kept emitting hourly `No ABI mapped for contract type MINTER` warnings (and `EventService` dropped its events undecoded).

New `ContractRepository.upsertCore` is now used in `registerCoreContracts` so the SDK-shipped type is authoritative on every boot.

## Test plan

- [x] `npm run build` (type-check) green
- [x] `prettier --check` clean on touched files
- [x] `eslint` clean on touched files
- [ ] DEV deploy: verify `0x760233...` flips from `MINTER` to `SAVINGS_V3` and the hourly WARN disappears
- [ ] DEV deploy: simulate GeckoTerminal/CoinGecko 502 and confirm the monitoring cycle aborts (telegram critical alert) instead of writing stale rates